### PR TITLE
chore: add live Emby API harness (stand-alone testing)

### DIFF
--- a/components/emby/api.py
+++ b/components/emby/api.py
@@ -41,16 +41,43 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
 
     def __init__(
         self,
-        hass: HomeAssistant,
+        hass: HomeAssistant | None,
         host: str,
         api_key: str,
         port: int,
         ssl: bool,
+        *,
+        session=None,
     ) -> None:
+        """Create a new minimal Emby API wrapper.
+
+        Parameters
+        ----------
+        hass
+            Home Assistant instance – **optional**.  When provided the helper
+            will reuse HA's shared aiohttp ClientSession.  When *None* a new
+            standalone session (or the supplied *session*) is used which makes
+            the class usable outside of Home Assistant e.g. in unit tests or
+            simple scripts.
+        session
+            Pre-created aiohttp `ClientSession` (optional).  Ignored when
+            *hass* is supplied because we must use HA's managed session in that
+            context.
+        """
+
         self._hass = hass
         self._base = f"{'https' if ssl else 'http'}://{host}:{port}"
         self._headers = {"X-Emby-Token": api_key}
-        self._session = async_get_clientsession(hass)
+
+        if hass is not None:
+            self._session = async_get_clientsession(hass)
+        else:
+            # Stand-alone mode – use provided session or create a new one.
+            if session is None:
+                import aiohttp
+
+                session = aiohttp.ClientSession()
+            self._session = session
 
         # Very small in-memory cache for the sessions list – refreshed at most
         # every `_CACHE_TTL` seconds to reduce HTTP round-trips during rapid

--- a/components/emby/api.py
+++ b/components/emby/api.py
@@ -44,7 +44,7 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         hass: HomeAssistant | None,
         host: str,
         api_key: str,
-        port: int,
+        port: int | None = None,
         ssl: bool,
         *,
         session=None,
@@ -66,7 +66,11 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         """
 
         self._hass = hass
-        self._base = f"{'https' if ssl else 'http'}://{host}:{port}"
+        scheme = 'https' if ssl else 'http'
+        if port is None:
+            self._base = f"{scheme}://{host}"
+        else:
+            self._base = f"{scheme}://{host}:{port}"
         self._headers = {"X-Emby-Token": api_key}
 
         if hass is not None:

--- a/devtools/emby_harness.py
+++ b/devtools/emby_harness.py
@@ -1,0 +1,66 @@
+"""Live test harness for the *minimal* Emby API wrapper.
+
+Usage::
+
+    export EMBY_URL="http://your-emby:8096"
+    export EMBY_API_KEY="xxxxxxxxxxxxxxxx"
+
+    python -m devtools.emby_harness --search "The Matrix"
+
+The script is **optional** – it only runs if the required environment
+variables are set.  It can be executed on its own without a running Home
+Assistant instance, which helps rapid development of the Emby helper classes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from urllib.parse import urlparse
+
+
+async def _amain() -> None:  # noqa: ANN201
+    from components.emby.api import EmbyAPI  # local import for editable repo
+
+    emby_url = os.getenv("EMBY_URL")
+    api_key = os.getenv("EMBY_API_KEY")
+
+    if not emby_url or not api_key:
+        print("EMBY_URL and/or EMBY_API_KEY environment variables not set – nothing to do.")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Quick Emby API helper harness")
+    parser.add_argument("--search", help="Search term to look for in the library", default=None)
+    args = parser.parse_args()
+
+    parsed = urlparse(emby_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (8920 if parsed.scheme == "https" else 8096)
+    ssl = parsed.scheme == "https"
+
+    api = EmbyAPI(None, host, api_key, port, ssl)
+
+    sessions = await api.get_sessions(force_refresh=True)
+    print(f"Active sessions: {len(sessions)}")
+    for sess in sessions:
+        device = sess.get("DeviceName") or sess.get("Client")
+        print(f" • {sess.get('Id')}  {device}  State={sess.get('PlayState', {}).get('State')}")
+
+    if args.search:
+        results = await api.search(search_term=args.search, limit=5)
+        print("Search results:")
+        for itm in results:
+            print(f" • {itm.get('Id')}  {itm.get('Name')}  ({itm.get('Type')})")
+
+
+def main() -> None:  # noqa: ANN001 – entrypoint
+    try:
+        asyncio.run(_amain())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/devtools/emby_harness.py
+++ b/devtools/emby_harness.py
@@ -37,7 +37,7 @@ async def _amain() -> None:  # noqa: ANN201
 
     parsed = urlparse(emby_url)
     host = parsed.hostname or "localhost"
-    port = parsed.port or (8920 if parsed.scheme == "https" else 8096)
+    port = parsed.port  # can be None
     ssl = parsed.scheme == "https"
 
     api = EmbyAPI(None, host, api_key, port, ssl)

--- a/devtools/hass_emby_harness.py
+++ b/devtools/hass_emby_harness.py
@@ -1,0 +1,118 @@
+"""Mini Home Assistant harness to exercise the Emby *platform* outside a full HA install.
+
+This launches an in-memory Home Assistant instance, loads **only** the
+`emby` media_player platform we maintain in this repo and wires it up to the
+real Emby server specified via environment variables (or CLI flags).
+
+It is *not* a replacement for proper unit/integration tests but offers a quick
+interactive way to validate end-to-end behaviour (device discovery, state
+updates, play/pause remote control) without running an entire HA container.
+
+Requirements
+------------
+The `homeassistant` Python package **must** be installed in your environment
+(it already is in the Codespace).  No additional configuration files are
+created – everything runs inside a temporary directory.
+
+Usage::
+
+    export EMBY_URL=https://my.emby.local
+    export EMBY_API_KEY=abcd1234
+
+    python -m devtools.hass_emby_harness
+
+The script will listen for devices for ~15 seconds, print any entities that
+appear and exit.  Feel free to tweak the timeout with `--duration`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import pathlib
+import sys
+from urllib.parse import urlparse
+
+
+def _parse_embro_url(url: str):
+    parsed = urlparse(url)
+    return parsed.hostname or "localhost", parsed.port, parsed.scheme == "https"
+
+
+async def _amain() -> None:  # noqa: ANN201 – script entrypoint
+    try:
+        from homeassistant.core import HomeAssistant, callback
+        from homeassistant.const import (
+            CONF_API_KEY,
+            CONF_HOST,
+            CONF_PORT,
+            CONF_SSL,
+            EVENT_HOMEASSISTANT_START,
+        )
+    except ImportError:
+        print("homeassistant package not available – cannot run harness.")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Home Assistant – Emby component harness")
+    parser.add_argument("--url", default=os.getenv("EMBY_URL"), help="Base Emby URL")
+    parser.add_argument("--api-key", default=os.getenv("EMBY_API_KEY"), help="Emby API key")
+    parser.add_argument("--duration", type=int, default=15, help="Seconds to keep HA running")
+    args = parser.parse_args()
+
+    if not args.url or not args.api_key:
+        print("Both --url/EMBY_URL and --api-key/EMBY_API_KEY are required.")
+        sys.exit(1)
+
+    host, port, ssl = _parse_embro_url(args.url)
+
+    # ------------------------------------------------------------------
+    # Minimal Home Assistant bootstrap
+    # ------------------------------------------------------------------
+
+    config_dir = pathlib.Path("./.ha_tmp").absolute()
+    config_dir.mkdir(exist_ok=True)
+
+    hass = HomeAssistant(str(config_dir))
+
+    # Inject our own platform config directly – we bypass configuration.yaml.
+    platform_config = {
+        CONF_HOST: host,
+        CONF_API_KEY: args.api_key,
+        CONF_SSL: ssl,
+    }
+    if port:
+        platform_config[CONF_PORT] = port
+
+    from components.emby.media_player import async_setup_platform  # local import
+
+    entities = []
+
+    @callback
+    def add_entities_callback(new_entities, update_before_add=False):  # noqa: D401, ANN001
+        entities.extend(new_entities)
+        print(f"[HA] New entities added: {new_entities}")
+
+    # Set up the platform manually – we don't load via discovery flow.
+    await async_setup_platform(hass, platform_config, add_entities_callback, None)
+
+    # Fire the start event so the platform can connect.
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    print("[HA] Home Assistant running – waiting for devices…")
+    await asyncio.sleep(args.duration)
+
+    print("[HA] Entities discovered:")
+    for ent in entities:
+        print(f" • {ent.name}  state={ent.state}  session={getattr(ent, 'get_current_session_id', lambda: None)()}")
+
+
+def main() -> None:  # noqa: ANN001 – script entrypoint
+    try:
+        asyncio.run(_amain())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces:\n\n* devtools/emby_harness.py – a simple async script that talks directly to a running Emby server using EMBY_URL and EMBY_API_KEY env vars. This lets us manually verify /Sessions, /Items search, and /Sessions/{id}/Playing calls without spinning up Home Assistant.\n* EmbyAPI enhancement – optional  param and  mode so it can run outside of HA.\n\nPart of epic #3 for iterative testing.]}