### PR TITLE
feat(api): library & children helper methods (closes #26)

### DIFF
--- a/components/emby/api.py
+++ b/components/emby/api.py
@@ -89,6 +89,20 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         self._sessions_cache: list[dict[str, Any]] = []
         self._sessions_cached_at: float = 0.0
 
+        # --------------------------------------------------------------
+        # Simple in-memory caches for library & children helpers
+        # --------------------------------------------------------------
+
+        # Keyed by `(user_id,)` – stores a tuple of (timestamp, data)
+        self._views_cache: dict[tuple[str], tuple[float, list[dict[str, Any]]]] = {}
+
+        # Keyed by `(item_id, start_index, limit, user_id)` – stores a tuple
+        # of (timestamp, payload).  The query parameters are part of the key
+        # because pagination may request overlapping but distinct slices.
+        self._children_cache: dict[
+            tuple[str | int, int, int, str | None], tuple[float, dict[str, Any]]
+        ] = {}
+
         _LOGGER.debug("Initialised EmbyAPI for %s", self._base)
 
     # ---------------------------------------------------------------------
@@ -181,6 +195,81 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         except EmbyApiError:
             # 404 or other errors -> treat as not-found
             return None
+
+    # ------------------------------------------------------------------
+    # New helpers – used by media browsing implementation (issue #26)
+    # ------------------------------------------------------------------
+
+    async def get_user_views(
+        self,
+        user_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> list[dict[str, Any]]:  # noqa: ANN401 – JSON payload
+        """Return the list of libraries / *views* for *user_id*.
+
+        The Emby endpoint returns either a plain list or an object wrapping
+        the list under an ``Items`` key depending on the server version.  The
+        helper normalises the output to *always* be a list to simplify caller
+        code.
+        """
+
+        cache_key = (user_id,)
+        cached = self._views_cache.get(cache_key)
+        if not force_refresh and cached and (time.time() - cached[0]) < self._CACHE_TTL:
+            return cached[1]
+
+        payload = await self._request("GET", f"/Users/{user_id}/Views")
+
+        # Normalise to a flat list
+        if isinstance(payload, dict):
+            views = payload.get("Items", [])
+        elif isinstance(payload, list):
+            views = payload
+        else:
+            raise EmbyApiError("Unexpected payload from /Views endpoint")
+
+        # Cache & return
+        self._views_cache[cache_key] = (time.time(), views)
+        return views
+
+    async def get_item_children(
+        self,
+        item_id: str | int,
+        *,
+        user_id: str | None = None,
+        start_index: int = 0,
+        limit: int = 100,
+        force_refresh: bool = False,
+    ) -> dict[str, Any]:  # noqa: ANN401 – JSON payload
+        """Return children for an item – wrapper around `/Items/{Id}/Children`.
+
+        The helper exposes simple pagination parameters mirroring the Emby API
+        (`StartIndex`, `Limit`).  Callers can iterate by adjusting these
+        values.  The raw payload (dict) is returned unchanged to retain
+        ``TotalRecordCount`` and other metadata.
+        """
+
+        cache_key = (item_id, start_index, limit, user_id)
+        cached = self._children_cache.get(cache_key)
+        if not force_refresh and cached and (time.time() - cached[0]) < self._CACHE_TTL:
+            return cached[1]
+
+        params: dict[str, str] = {
+            "StartIndex": str(start_index),
+            "Limit": str(limit),
+        }
+        if user_id:
+            params["UserId"] = user_id
+
+        payload = await self._request("GET", f"/Items/{item_id}/Children", params=params)
+
+        if not isinstance(payload, dict):
+            raise EmbyApiError("Unexpected payload from /Children endpoint – expected JSON object")
+
+        # Cache & return
+        self._children_cache[cache_key] = (time.time(), payload)
+        return payload
 
     # ------------------------------------------------------------------
     # Internal utilities

--- a/tests/unit/emby/test_api_library_helpers.py
+++ b/tests/unit/emby/test_api_library_helpers.py
@@ -1,0 +1,102 @@
+"""Unit tests for the *library* helper methods added in issue #26.
+
+These cover:
+* `get_user_views()` – correct HTTP path, normalisation & caching.
+* `get_item_children()` – correct HTTP path/query parameters & caching.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from types import SimpleNamespace
+
+import pytest
+
+from components.emby.api import EmbyAPI
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding – simple recorder that fakes `_request` responses.
+# ---------------------------------------------------------------------------
+
+
+class _RequestRecorder:
+    """Helper that records calls and returns stubbed responses."""
+
+    def __init__(self):
+        self.calls: list[Dict[str, Any]] = []
+
+    async def __call__(self, method: str, path: str, **kwargs):  # noqa: D401
+        self.calls.append({"method": method, "path": path, **kwargs})
+
+        # Return dummy payloads depending on the endpoint requested.
+        if path.endswith("/Views"):
+            return {"Items": [{"Id": "lib-1", "Name": "Movies"}]}
+
+        if path.endswith("/Children"):
+            return {
+                "Items": [
+                    {"Id": "child-1", "Name": "Item 1"},
+                    {"Id": "child-2", "Name": "Item 2"},
+                ],
+                "TotalRecordCount": 2,
+            }
+
+        raise AssertionError(f"Unexpected path requested in test: {path}")
+
+
+# ---------------------------------------------------------------------------
+# Tests – get_user_views()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_user_views_normalises_and_caches(monkeypatch):
+    recorder = _RequestRecorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    # First call performs HTTP request and returns normalised *list*.
+    libs1 = await api.get_user_views("user-123")
+    assert libs1 == [{"Id": "lib-1", "Name": "Movies"}]
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0]["path"] == "/Users/user-123/Views"
+
+    # Second call without force-refresh should hit cache (no extra HTTP).
+    libs2 = await api.get_user_views("user-123")
+    assert libs2 is libs1
+    assert len(recorder.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests – get_item_children()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_item_children_params_and_caching(monkeypatch):
+    recorder = _RequestRecorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    payload1 = await api.get_item_children(
+        "parent-1", user_id="user-123", start_index=10, limit=5
+    )
+
+    # Verify the response is forwarded unchanged.
+    assert payload1["TotalRecordCount"] == 2
+    assert len(recorder.calls) == 1
+
+    call = recorder.calls[0]
+    assert call["path"] == "/Items/parent-1/Children"
+
+    # Query params must be correctly forwarded.
+    expected_params = {"StartIndex": "10", "Limit": "5", "UserId": "user-123"}
+    assert call["params"] == expected_params
+
+    # Second identical call should be served from cache.
+    payload2 = await api.get_item_children(
+        "parent-1", user_id="user-123", start_index=10, limit=5
+    )
+    assert payload2 is payload1
+    assert len(recorder.calls) == 1  # no extra HTTP


### PR DESCRIPTION
### Summary
Adds the helper endpoints required for upcoming media browsing support.

- `get_user_views()` — retrieves user libraries (`/Users/{id}/Views`) with small in-memory cache and list normalisation.
- `get_item_children()` — wraps `/Items/{id}/Children` with pagination parameters and cache.

Comes with unit tests verifying the correct HTTP paths/params and caching behaviour.

Fixes #26.
