### PR TITLE
docs: add media browsing docs (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional `enqueue`, `position`) to start playback or queue items on any Emby
   client.  See the updated README for usage examples.  *(epic #3 – closes
   issue #12)*
+
+* **Media browsing** – Navigate your Emby libraries directly inside Home
+  Assistant via the **Browse Media** dialog.  Libraries, collections, seasons
+  and items are represented with full artwork and metadata.  Delegates to the
+  built-in `media_source` integration for TTS and local files. *(epic #24 –
+  closes issues #25–#29)*

--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@ server – movies, TV, music and more – to Home Assistant.  Once configured yo
 can browse your library, trigger playback on Emby clients, build automation
 around play state changes and combine everything with the rich HA ecosystem.
 
+Key features:
+
+• 💿 **Browse Media** – visually navigate your Emby libraries from Home
+  Assistant and start playback with a click.
+• ▶️ **Play Media** – powerful resolver that supports titles, seasons, exact
+  Emby IDs and more.
+• 🔄 **Automations ready** – every browse item works seamlessly with
+  `media_player.play_media`, making automations trivial.
+
 This README focuses on the `media_player.play_media` functionality added in
-version `0.5.0` (see CHANGELOG).  For full installation & configuration details
-see the sections below.
+version `0.6.0` (see CHANGELOG).  The latest release also introduces **native
+media browsing** – letting you navigate your Emby libraries directly inside the
+Home Assistant UI and start playback with a single click.  For full
+installation & configuration details see the sections below.
 
 ---
 
@@ -106,6 +117,57 @@ The internal resolver is quite smart – it will try exact Emby Item IDs first,
 then fall back to title search across libraries, seasons/episodes, artists &
 tracks.  Ambiguous searches raise a clear error so your automations never hang
 silently.
+
+---
+
+## Browsing your Emby library in the UI  _(new in v0.6.0)_
+
+From Home Assistant 2023.5 the **Browse Media** dialog became the preferred way
+for users to explore their libraries and enqueue content.  The Emby
+integration now implements `async_browse_media`, which means:
+
+1. Click **Media → Browse media** (or the ✚ icon in Automations/Scenes).
+2. Choose one of your connected Emby players.
+3. Navigate through Libraries → Collections/Seasons → Items.
+4. Tap a playable leaf item (movie, episode, track, playlist) to start
+   playback instantly.
+
+The navigation hierarchy matches what you see in the Emby web dashboard:
+
+• **Libraries** – eg. *Movies*, *TV Shows*, *Music*\
+• **Collections / Folders** – box-sets, TV seasons, artist albums\
+• **Items** – individual movies, episodes, songs, channels…
+
+Each tile is enriched with artwork and the correct media class so Home
+Assistant can display appropriate icons and actions.  Pagination is handled
+transparently – large libraries still load quickly and expose *Next / Previous*
+folders for efficient navigation when required.
+
+### Mixing local media & TTS
+
+If you browse to **Media Source** paths such as `media-source://tts` the
+integration automatically delegates to the built-in `media_source`
+integration.  This keeps text-to-speech and local file playback working exactly
+as before.
+
+### Automations & scripts
+
+The browse dialog is the fastest way to visually pick an item – but you can
+also feed the resulting `media_content_id` straight back into the
+`media_player.play_media` service (for example in a script).  Under the hood
+the ID uses an `emby://` schema followed by the Emby ItemId so look-ups are
+reliable and language-agnostic.
+
+```yaml
+service: media_player.play_media
+target:
+  entity_id: media_player.emby_lounge_tv
+data:
+  media_type: movie
+  media_id: "emby://item/123456789abcdef"  # generated from the browse dialog
+```
+
+---
 
 ---
 

--- a/docs/emby/media_browsing.md
+++ b/docs/emby/media_browsing.md
@@ -1,0 +1,90 @@
+# Media Browsing
+
+Home Assistant exposes a generic **Browse Media** dialog which integrations can
+hook into to provide a rich navigation tree.  As of version `0.6.0` the Emby
+integration fully implements this capability through the
+`media_player.async_browse_media` API.
+
+---
+
+## Quick start
+
+1. Open the left-hand **Media** panel in Home Assistant.
+2. Click **Browse media** then pick any Emby player entity.
+3. Choose a library (Movies, TV Shows, Music, …).
+4. Drill down into collections / folders until you reach a playable item.
+5. Hit the artwork tile to start playback instantly on the selected client.
+
+![Browse Emby root](../images/browse_root.png)
+![Browse Emby movies](../images/browse_movies.png)
+
+_Screenshots are illustrative – your artwork and library names will differ._
+
+---
+
+## Hierarchy mapping
+
+| Emby Object            | HA `media_class`            | `can_play` | `can_expand` |
+|------------------------|-----------------------------|------------|--------------|
+| Library (View)         | `directory`                 | ❌         | ✅           |
+| Collection / Folder    | `directory`                 | ❌         | ✅           |
+| TV Season              | `season`                    | ❌         | ✅           |
+| Movie                  | `movie`                     | ✅         | ❌           |
+| Episode                | `episode`                   | ✅         | ❌           |
+| Music Album            | `album`                     | ✅         | ✅ (tracks)  |
+| Song / Track           | `music`                     | ✅         | ❌           |
+| Playlist               | `playlist`                  | ✅         | ❌           |
+
+The integration translates Emby item types into the closest matching Home
+Assistant `media_class` so the frontend can decorate each tile appropriately.
+
+---
+
+## Deep linking & automations
+
+Every tile in the browse tree exposes a stable `media_content_id` that starts
+with the custom schema `emby://`.  Example:
+
+```
+emby://item/9d2c6723d5c175afcd9f5e9d1f4b5678
+```
+
+You can copy this ID (e.g. via automation UI) and feed it directly into
+`media_player.play_media` – either manually or programmatically – to trigger
+playback without going through the browse dialog.
+
+```yaml
+service: media_player.play_media
+target:
+  entity_id: media_player.emby_projector
+data:
+  media_type: movie
+  media_id: "emby://item/9d2c6723d5c175afcd9f5e9d1f4b5678"
+```
+
+---
+
+## Mixing in other sources
+
+When the requested ID starts with `media-source://` the Emby integration
+delegates the call back to the built-in `media_source` integration so local
+files, TTS and cloud providers keep working as expected.  This means you can
+seamlessly blend local jingles or announcements into your Emby driven
+automations.
+
+---
+
+## Troubleshooting
+
+• *Item not found* – The associated Emby item has been deleted or is no longer
+  accessible to the user configured in the integration.  Re-scan libraries or
+  regenerate the link via the browse dialog.
+• *Empty library* – Ensure the user account used by Home Assistant has
+  permission to view the libraries in Emby server settings.
+
+For further assistance please open an issue on GitHub with debug logs
+(`logger: components.emby: debug`).
+
+---
+
+_Document generated automatically by Codex 🤖_


### PR DESCRIPTION
This PR adds documentation for the new media browsing feature and updates the README & CHANGELOG. Fixes #30.