### PR TITLE
ci: add release & changelog workflow (closes #52)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,17 @@ jobs:
           CLEAN_TAG="${RAW_REF#v}"
           echo "::set-output name=version::${CLEAN_TAG}"
 
-      - name: 🛠️  Set manifest version to match tag
+      - name: 🛠️  Set manifest version to match tag (preserve formatting)
         run: |
           VERSION="${{ steps.vars.outputs.version }}"
           MANIFEST="custom_components/embymedia/manifest.json"
-          echo "Setting version in ${MANIFEST} to ${VERSION}"
-          # Use jq to update the JSON while preserving formatting as best as possible.
-          TMP=$(mktemp)
-          jq --arg v "$VERSION" '.version = $v' "$MANIFEST" > "$TMP"
-          mv "$TMP" "$MANIFEST"
+
+          echo "Updating version in ${MANIFEST} to ${VERSION} (formatting preserved)"
+
+          # Use sed to replace the version value in-place without reformatting the JSON.
+          # Matches a line that begins with optional spaces, then "version": "<digits>..." and replaces the value.
+          # Assumes the manifest keeps the `version` key on a single line (Home-Assistant convention).
+          sed -i -E "s/(\"version\"\s*:\s*\")([0-9]+(\.[0-9]+)*)(\")/\1${VERSION}\4/" "$MANIFEST"
 
       - name: 💾 Commit manifest bump (if any)
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,16 +50,22 @@ jobs:
           CLEAN_TAG="${RAW_REF#v}"
           echo "::set-output name=version::${CLEAN_TAG}"
 
-      - name: ✅ Validate manifest version matches tag
+      - name: 🛠️  Set manifest version to match tag
         run: |
-          TAG="${{ steps.vars.outputs.version }}"
-          MANIFEST_VERSION=$(jq -r .version custom_components/embymedia/manifest.json)
-          echo "Git tag version: ${TAG}"
-          echo "Manifest version: ${MANIFEST_VERSION}"
-          if [ "${TAG}" != "${MANIFEST_VERSION}" ]; then
-            echo "::error::Version mismatch – bump manifest.json to ${TAG} before tagging."
-            exit 1
-          fi
+          VERSION="${{ steps.vars.outputs.version }}"
+          MANIFEST="custom_components/embymedia/manifest.json"
+          echo "Setting version in ${MANIFEST} to ${VERSION}"
+          # Use jq to update the JSON while preserving formatting as best as possible.
+          TMP=$(mktemp)
+          jq --arg v "$VERSION" '.version = $v' "$MANIFEST" > "$TMP"
+          mv "$TMP" "$MANIFEST"
+
+      - name: 💾 Commit manifest bump (if any)
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(manifest): bump version to v${{ steps.vars.outputs.version }}"
+          commit_user_name: GitHub Action
+          commit_user_email: action@github.com
 
       - name: 📝 Generate / update CHANGELOG.md
         uses: TriPSs/conventional-changelog-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release & Changelog
+
+# Creates a versioned GitHub release including a packaged copy of the
+# Home-Assistant integration and automatically updates the local CHANGELOG.
+#
+# Triggers:
+#  * Manual dispatch so maintainers can test the workflow.
+#  * Push of a semantic-version tag that starts with `v` (e.g. `v0.1.0`).
+#
+# The workflow performs the following steps:
+# 1. Checks out the repository with full history (required for changelog).
+# 2. Verifies that the version in `custom_components/embymedia/manifest.json`
+#    matches the git tag (guards against forgotten bumps).
+# 3. Regenerates `CHANGELOG.md` from the commit history using conventional
+#    commits and, where changes were produced, commits the updated changelog
+#    back to `main`.
+# 4. Packages `custom_components/embymedia/**` into a ZIP archive that is
+#    suitable for HACS installation.
+# 5. Publishes a GitHub release using `softprops/action-gh-release`, attaching
+#    the generated ZIP and auto-generated release notes.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  # The default GITHUB_TOKEN is granted the minimum required scopes (contents)
+  # so explicit declaration keeps the job self-contained and future-proof.
+  contents: write
+
+jobs:
+  release:
+    name: Build & publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # full history for conventional-changelog
+
+      - name: 🏷️ Extract version information
+        id: vars
+        run: |
+          # Remove the leading `refs/tags/` and optional `v` prefix.
+          RAW_REF="${GITHUB_REF#refs/tags/}"
+          echo "::set-output name=tag::${RAW_REF}"
+          CLEAN_TAG="${RAW_REF#v}"
+          echo "::set-output name=version::${CLEAN_TAG}"
+
+      - name: ✅ Validate manifest version matches tag
+        run: |
+          TAG="${{ steps.vars.outputs.version }}"
+          MANIFEST_VERSION=$(jq -r .version custom_components/embymedia/manifest.json)
+          echo "Git tag version: ${TAG}"
+          echo "Manifest version: ${MANIFEST_VERSION}"
+          if [ "${TAG}" != "${MANIFEST_VERSION}" ]; then
+            echo "::error::Version mismatch – bump manifest.json to ${TAG} before tagging."
+            exit 1
+          fi
+
+      - name: 📝 Generate / update CHANGELOG.md
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: CHANGELOG.md
+          skip-on-no-changes: true
+          tag-prefix: 'v'
+
+      - name: 📦 Create integration zip
+        run: |
+          ZIP_NAME="embymedia-${{ steps.vars.outputs.version }}.zip"
+          cd custom_components
+          zip -r "../${ZIP_NAME}" embymedia
+          echo "Created artifact $(pwd)/../${ZIP_NAME}"
+
+      - name: 🚀 Publish GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          name: Emby for Home Assistant ${{ steps.vars.outputs.version }}
+          generate_release_notes: true
+          files: embymedia-${{ steps.vars.outputs.version }}.zip


### PR DESCRIPTION
### Summary
Adds a reusable GitHub Actions workflow that builds and publishes a versioned release when either:

* a semantic-version tag (`v*`) is pushed, **or**
* the workflow is run manually via the *Run workflow* button.

### Key features

* **Synchronises versions** – the workflow now **writes** the tag version into `custom_components/embymedia/manifest.json` (and commits the change) so the manifest always matches the release.
* Regenerates `CHANGELOG.md` using conventional commits (`TriPSs/conventional-changelog-action@v3`) and commits the file back to **main** when changes are detected.
* Packages the integration directory into a ZIP archive suitable for HACS installation.
* Publishes the release through `softprops/action-gh-release@v1`, attaching the generated ZIP and auto-generated release notes.

This satisfies the acceptance criteria for #52 and moves the project a step closer to HACS publication.

---
*Generated by Codex CLI*
