### PR TITLE
feat(api): extend EmbyAPI with remote-control helpers (closes #79)

### DIFF
--- a/tests/unit/emby/test_api_helper_commands.py
+++ b/tests/unit/emby/test_api_helper_commands.py
@@ -1,0 +1,139 @@
+"""Unit tests for the extra *remote-control* helpers added by issue #79.
+
+The tests validate that each public wrapper funnels into the private
+``_request`` helper with the correct HTTP method, path and JSON payload.  A
+light-weight *recorder* stub is injected via monkeypatching so the helper can
+be inspected without performing real network I/O.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from typing import Any, Dict
+
+import pytest
+
+from custom_components.embymedia.api import EmbyAPI
+
+
+class _Recorder:
+    """Replaces :py:meth:`EmbyAPI._request` to capture outgoing calls."""
+
+    def __init__(self) -> None:  # noqa: D401 – simple initialiser
+        self.calls: list[Dict[str, Any]] = []
+
+    async def __call__(self, method: str, path: str, **kwargs):  # noqa: D401 – async callback
+        self.calls.append({"method": method, "path": path, **kwargs})
+        # All helper methods expect an *empty* response body.
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# set_volume – clamps & sends VolumeSet command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_level,expected_pct", [(0.0, 0), (0.5, 50), (1.0, 100), (-1, 0), (2, 100)])
+async def test_set_volume_sends_correct_json(monkeypatch, input_level, expected_pct):
+    recorder = _Recorder()
+
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    await api.set_volume("sess-X", input_level)
+
+    assert len(recorder.calls) == 1
+    call = recorder.calls[0]
+
+    assert call["method"] == "POST"
+    assert call["path"] == "/Sessions/sess-X/Command"
+
+    payload = call["json"]
+    assert payload["Name"] == "VolumeSet"
+    assert payload["Arguments"]["Volume"] == str(expected_pct)
+
+
+# ---------------------------------------------------------------------------
+# mute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mute_flag,expected_str", [(True, "true"), (False, "false")])
+async def test_mute_command(monkeypatch, mute_flag, expected_str):
+    recorder = _Recorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    await api.mute("sess-1", mute_flag)
+
+    payload = recorder.calls[0]["json"]
+    assert payload["Name"] == "Mute"
+    assert payload["Arguments"]["Mute"] == expected_str
+
+
+# ---------------------------------------------------------------------------
+# shuffle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shuffle_command(monkeypatch):
+    recorder = _Recorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    await api.shuffle("sess-2", True)
+
+    payload = recorder.calls[0]["json"]
+    assert payload["Name"] == "Shuffle"
+    assert payload["Arguments"]["Shuffle"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# repeat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["RepeatNone", "RepeatAll", "RepeatOne"])
+async def test_repeat_valid_modes(monkeypatch, mode):
+    recorder = _Recorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    await api.repeat("sess-3", mode)
+
+    payload = recorder.calls[0]["json"]
+    assert payload["Name"] == "Repeat"
+    assert payload["Arguments"]["Mode"] == mode
+
+
+@pytest.mark.asyncio
+async def test_repeat_invalid_mode_raises(monkeypatch):
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+
+    with pytest.raises(ValueError):
+        await api.repeat("sess-3", "InvalidMode")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# power_state – on & off
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_power_state_command(monkeypatch):
+    recorder = _Recorder()
+    api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
+    monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
+
+    await api.power_state("sess-on", True)
+    await api.power_state("sess-off", False)
+
+    first, second = recorder.calls
+
+    assert first["json"]["Name"] == "DisplayOn"
+    assert second["json"]["Name"] == "Standby"


### PR DESCRIPTION
### Summary
This PR implements **issue #79** and unlocks additional media-player capabilities required by the remaining epic tasks (#72).  The `EmbyAPI` wrapper is extended with a tiny, typed surface that covers

* Absolute volume setting
* Muting / un-muting
* Shuffle toggle
* Repeat mode cycle
* Power on / standby

All helpers reuse a single private `_post_session_command()` utility which posts a `GeneralCommand` payload to `/Sessions/{id}/Command`.  This keeps the wrapper minimal while exposing the heavy-lifters needed by entity code.

### Changes
1. **`custom_components/embymedia/api.py`**
   * new `_post_session_command()` internal helper
   * public methods: `set_volume`, `mute`, `shuffle`, `repeat`, `power_state`
   * arg validation (volume clamping, repeat-mode check)
2. **Tests** – `tests/unit/emby/test_api_helper_commands.py`
   * Assert correct HTTP verb, path and JSON body for every wrapper
   * Edge-cases covered (volume bounds, invalid repeat)  
   * Entire test-suite now at **56/56 green**

### Validation
```bash
pytest -q         # → 56 passed
pyright -p .      # → 0 errors / 0 warnings
```

### Checklist
- [x] Code follows existing style & lint rules (Ruff/Pyright)
- [x] Unit tests added and passing
- [x] No secrets or private data committed
- [x] Linked to **#79** and closes it on merge

*Reviewer notes:* These helpers are intentionally thin — entity-level tasks (#75-#78) will build upon them without duplicating HTTP logic.
