### PR TITLE
fix: release workflow fails in detached HEAD (closes #99)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,14 @@ jobs:
           skip-on-empty: true
           tag-prefix: 'v'
           git-branch: main
+          # The checkout action leaves the repository in a detached HEAD
+          # state when the workflow is triggered from a tag push.  The
+          # conventional-changelog action attempts a `git pull` immediately
+          # which fails because we are not on a branch yet.  Skipping the
+          # pull step avoids the failure – we explicitly fetch the full
+          # history above and will commit any CHANGELOG updates directly to
+          # `main` below.
+          skip-git-pull: true
 
       - name: 📦 Create integration zip
         run: |


### PR DESCRIPTION
### Summary of changes
* Added `skip-git-pull: true` to the `TriPSs/conventional-changelog-action` step in `.github/workflows/release.yml`.
* This prevents the release job from running `git pull` while in a detached-HEAD state, resolving the failure observed in #99.

### Notes for the reviewer
The workflow still fetches full history (`fetch-depth: 0`) and commits CHANGELOG updates directly to `main`, so skipping the pull is safe.

Closes #99
