### PR TITLE
fix: expose browse/search/enqueue/announce feature flags (closes #108)

### DIFF
--- a/custom_components/embymedia/media_player.py
+++ b/custom_components/embymedia/media_player.py
@@ -238,6 +238,28 @@ SUPPORT_EMBY = (
         if hasattr(MediaPlayerEntityFeature, "TURN_OFF")
         else MediaPlayerEntityFeature(0)
     )
+    # Issue #108 – expose browse, search, enqueue & announce capabilities so
+    # the Home Assistant UI renders the Media panel and related controls.
+    | (
+        MediaPlayerEntityFeature.BROWSE_MEDIA
+        if hasattr(MediaPlayerEntityFeature, "BROWSE_MEDIA")
+        else MediaPlayerEntityFeature(0)
+    )
+    | (
+        MediaPlayerEntityFeature.SEARCH_MEDIA
+        if hasattr(MediaPlayerEntityFeature, "SEARCH_MEDIA")
+        else MediaPlayerEntityFeature(0)
+    )
+    | (
+        MediaPlayerEntityFeature.MEDIA_ENQUEUE
+        if hasattr(MediaPlayerEntityFeature, "MEDIA_ENQUEUE")
+        else MediaPlayerEntityFeature(0)
+    )
+    | (
+        MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+        if hasattr(MediaPlayerEntityFeature, "MEDIA_ANNOUNCE")
+        else MediaPlayerEntityFeature(0)
+    )
 )
 
 PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(

--- a/tests/unit/emby/test_dynamic_supported_features.py
+++ b/tests/unit/emby/test_dynamic_supported_features.py
@@ -85,5 +85,29 @@ def test_supported_features_updates_on_capability_change(emby_device):  # noqa: 
     emby_device.async_update_callback({})  # type: ignore[arg-type]
 
     from custom_components.embymedia.media_player import SUPPORT_EMBY
+    assert emby_device.supported_features == SUPPORT_EMBY
 
     assert emby_device.supported_features == SUPPORT_EMBY
+
+    # ------------------------------------------------------------------
+    # Additional explicit checks for new capability flags (issue #108)
+    # ------------------------------------------------------------------
+
+    # Verify that the extended feature mask now includes browse, search,
+    # enqueue and announce capabilities when available in the running Core.
+
+    optional_flags = [
+        getattr(MediaPlayerEntityFeature, name, MediaPlayerEntityFeature(0))
+        for name in (
+            "BROWSE_MEDIA",
+            "SEARCH_MEDIA",
+            "MEDIA_ENQUEUE",
+            "MEDIA_ANNOUNCE",
+        )
+    ]
+
+    # All optional flags that exist in the current Home Assistant installation
+    # must be set in the computed feature mask.
+    for flag in optional_flags:
+        if flag != MediaPlayerEntityFeature(0):
+            assert emby_device.supported_features & flag == flag


### PR DESCRIPTION
## Overview
Expose the media-player capability flags introduced in Home Assistant 2025-04 so the Emby integration can surface the Media Browser and advanced playback controls.

## Motivation
Although the backend implementation already supports browsing, searching, enqueue and announce, the UI could not offer these features because the corresponding flags were missing from `supported_features`.

## Changes
1. Extend `SUPPORT_EMBY` with:
   * `BROWSE_MEDIA`
   * `SEARCH_MEDIA`
   * `MEDIA_ENQUEUE`
   * `MEDIA_ANNOUNCE`
   (all behind `hasattr` guards for backward-compatibility)
2. No behavioural change when the Emby device does *not* expose remote-control capabilities – the feature mask still collapses to `0` as before.
3. Extend unit test `test_dynamic_supported_features.py` to assert the presence of the new flags.

## Testing
```bash
pytest -q
........................................................................ [ 62%]
...........................................                             [100%]
115 passed in < 1 s
```

## Related issues
* Closes #108 (this PR will auto-close the task)
* Part of epic #103

## Reviewer notes
* The guards ensure older Home Assistant cores (prior to the 2025-04 spec) continue to import the integration without errors.
* Follow-up tasks (#109 – #111) rely on these flags to enable thumbnails and integration-level websocket tests.
