### PR TITLE
feat: security hardening & user-profile playback support (closes #123, #124, #125, #126)

### DIFF
--- a/custom_components/embymedia/api.py
+++ b/custom_components/embymedia/api.py
@@ -161,8 +161,21 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         *,
         play_command: str = "PlayNow",
         start_position_ticks: int | None = None,
+        controlling_user_id: str | None = None,
     ) -> None:
-        """Trigger playback of *item_ids* on the specified session."""
+        """Trigger playback of *item_ids* on the specified session.
+
+        Parameters
+        ----------
+        session_id
+            Target Emby *SessionId* obtained from the ``/Sessions`` endpoint.
+        item_ids
+            One or more *ItemId* values to be queued/played.
+        controlling_user_id
+            Optional Emby user id that should be recorded as the *controlling*
+            user.  When omitted Emby associates the command with the **admin**
+            account which may bypass parental controls.  See GitHub issue #125.
+        """
 
         params: Dict[str, str] = {
             "ItemIds": ",".join([str(i) for i in item_ids]),
@@ -170,6 +183,8 @@ class EmbyAPI:  # pylint: disable=too-few-public-methods
         }
         if start_position_ticks is not None:
             params["StartPositionTicks"] = str(start_position_ticks)
+        if controlling_user_id is not None:
+            params["ControllingUserId"] = controlling_user_id
 
         await self._request("POST", f"/Sessions/{session_id}/Playing", params=params, json={})
 


### PR DESCRIPTION
## Summary
This pull request completes epic **#121 – Align Emby browse media integration with HA guidelines** by delivering the four remaining subtasks.  All modifications are backwards-compatible and covered by unit tests.

## Changes
### 1. Harden `async_get_browse_image` (closes #123)
* Reject any `media_image_id` that contains `://` to prevent URL round-trips.
* Expanded docstring with security rationale.
* Added unit test `test_async_get_browse_image_reject_malicious_id`.

### 2. Remove deprecated helpers & stale comments (closes #124)
* Deleted `_build_thumbnail_url` shim.
* Pruned outdated issue references.

### 3. Expose **user selection** in `async_play_media` (closes #125)
* Added optional `user_id` in `PLAY_MEDIA_SCHEMA` and service signature.
* Propagated to `EmbyAPI.play(controlling_user_id=…)`.
* Updated tests; new test `test_async_play_media_with_user_id` verifies propagation.

### 4. Refresh test-suite (closes #126)
* Updated affected assertions.
* Total tests: **122** – all pass (`pytest -q`).

## Verification
```bash
pytest -q
# ➜  122 passed, 6 warnings in 0.50s
```

## Notes for reviewer (@troykelly)
* No breaking changes – `user_id` is optional.
* External behaviour unchanged except for stricter image validation.
* Ready for review & merge; merging will automatically close #123-#126 and the parent epic #121.
