### PR TITLE
feat: extend Emby item-type mapping (closes #133)

### DIFF
--- a/custom_components/embymedia/media_player.py
+++ b/custom_components/embymedia/media_player.py
@@ -143,6 +143,17 @@ _ITEM_TYPE_MAP: dict[str, tuple[MediaClass, str, bool, bool]] = {
     "TvChannel": (MediaClass.CHANNEL, "channel", True, False),
     "Trailer": (MediaClass.VIDEO, "video", True, False),
     "Video": (MediaClass.VIDEO, "video", True, False),
+
+    # Live-TV recording types – surfaced via the *Live TV* section in Emby.
+    # A *Recording* represents a single, directly playable file while
+    # *RecordingSeries* groups multiple recordings under the same schedule.
+    #
+    # BoxSet is Emby’s term for a curated collection of movies or shows.  It
+    # behaves like a folder from the user’s perspective.
+
+    "Recording": (MediaClass.VIDEO, "recording", True, False),
+    "RecordingSeries": (MediaClass.DIRECTORY, "recording_series", False, True),
+    "BoxSet": (MediaClass.DIRECTORY, "boxset", False, True),
 }
 
 # Fallback mapping for library / root views where `CollectionType` is returned
@@ -1014,6 +1025,12 @@ class EmbyDevice(MediaPlayerEntity):
             return MediaType.MUSIC
         if media_type == "TvChannel":
             return MediaType.CHANNEL
+        if media_type == "Recording":
+            return MediaType.VIDEO
+        if media_type == "RecordingSeries":
+            return "directory"
+        if media_type == "BoxSet":
+            return "directory"
         return None
 
     @property  # pyright: ignore[override]

--- a/tests/unit/emby/test_media_player_content_properties.py
+++ b/tests/unit/emby/test_media_player_content_properties.py
@@ -75,6 +75,9 @@ def test_media_content_id_passthrough(emby_device):  # noqa: D401
         ("Video", "video"),
         ("Audio", "music"),
         ("TvChannel", "channel"),
+        ("Recording", "video"),
+        ("RecordingSeries", "directory"),
+        ("BoxSet", "directory"),
         ("Unknown", None),
     ],
 )


### PR DESCRIPTION
### Summary

This PR expands the **Emby item-type → MediaClass/content_type** mapping with the additional object types surfaced by Emby Live-TV and curated movie collections.  It completes sub-task **#133** of the *Browse Media* epic (#129).

| Emby `Type`     | MediaClass | content_type       | can_play | can_expand |
|-----------------|------------|--------------------|----------|------------|
| Recording       | VIDEO      | `recording`        | ✅       |            |
| RecordingSeries | DIRECTORY  | `recording_series` |          | ✅         |
| BoxSet          | DIRECTORY  | `boxset`           |          | ✅         |

Key points:
1. `_ITEM_TYPE_MAP` updated with the new rows (incl. flags).
2. `EmbyDevice.media_content_type` returns meaningful values for the added types (VIDEO or `directory`).
3. Unit test `test_media_player_content_properties.py` extended to cover the new cases.

All tests pass:

```
pytest -q
126 passed, 6 warnings in 0.48s
```

### Checklist
- [x] Branch uses conventional name (`codex/issue-133-extend-item-type-map`)
- [x] Commits follow conventional style and include *Fixes #133* keyword
- [x] Added/updated unit tests
- [x] No breaking changes to public API

Please review 🙂
