### PR TITLE
docs: document virtual directories (Continue Watching & Favorites) [#135]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client.  See the updated README for usage examples.  *(epic #3 – closes
   issue #12)*
 
+* **Virtual directories – Continue Watching & Favorites** – The media browser
+  now surfaces two convenient shortcuts at the root level so you can resume
+  unfinished movies/episodes or jump straight into items you starred in Emby.
+  Both virtual folders fully support pagination and artwork just like physical
+  libraries. *(epic #129 – closes issue #135)*
+
 * **Media browsing** – Navigate your Emby libraries directly inside Home
   Assistant via the **Browse Media** dialog.  Libraries, collections, seasons
   and items are represented with full artwork and metadata.  Delegates to the


### PR DESCRIPTION
### Summary

Adds a short *Added* entry to the changelog for the new **Continue Watching** and **Favorites** virtual directories exposed by the media browser.

### Why?

The feature was implemented in earlier code changes but the epic task (#129) still had the documentation sub-issue (#135) open.  This PR completes that last mile and autocloses the task.

### Notes to reviewer

* No functional code changes – docs only.
* CI should run trivially fast.

Fixes #135