### PR TITLE
fix: correct default Emby ports (closes #181)

### DIFF
--- a/custom_components/embymedia/media_player.py
+++ b/custom_components/embymedia/media_player.py
@@ -212,8 +212,18 @@ _LOGGER = logging.getLogger(__name__)
 MEDIA_TYPE_TRAILER = "trailer"
 
 DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 80
-DEFAULT_SSL_PORT = 443
+# -----------------------------------------------------------------------------
+# Default Emby ports – fixes GitHub issue #181
+# -----------------------------------------------------------------------------
+# Emby's upstream defaults differ from the **generic** web ports used by the
+# original implementation.  The incorrect values (80/443) prevented the
+# integration from connecting when the user did **not** explicitly specify a
+# custom *port* in the YAML or Config-Flow set-up.  Update the constants to
+# match the upstream server defaults so that out-of-the-box configurations
+# work again.
+
+DEFAULT_PORT = 8096  # default HTTP port exposed by Emby
+DEFAULT_SSL_PORT = 8920  # default HTTPS port exposed by Emby
 DEFAULT_SSL = False
 
 SUPPORT_EMBY = (

--- a/tests/unit/emby/test_default_port_logic.py
+++ b/tests/unit/emby/test_default_port_logic.py
@@ -1,0 +1,129 @@
+"""Verify that *async_setup_platform* chooses the correct default port.
+
+The integration should honour the official Emby defaults when the user does
+**not** explicitly provide a *port* in the Home Assistant configuration or
+config-flow:
+
+* HTTP  – 8096
+* HTTPS – 8920
+
+Regression covered by GitHub issue #181.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+class _RecorderEmbyServer:  # pylint: disable=too-few-public-methods
+    """Light-weight stand-in for *pyemby.EmbyServer* that records init args."""
+
+    last_args: tuple | None = None  # (host, key, port, ssl, loop)
+
+    def __init__(self, host, key, port, ssl, loop):  # noqa: D401 – mimic signature
+        # Store the received arguments so the test can assert on them.
+        _RecorderEmbyServer.last_args = (host, key, port, ssl, loop)
+
+        # Minimal surface expected by the integration (not used in this test)
+        self.devices: dict = {}
+
+    # Stubbed convenience helpers ------------------------------------------------
+    def add_new_devices_callback(self, _cb):  # noqa: D401
+        return None
+
+    def add_stale_devices_callback(self, _cb):  # noqa: D401
+        return None
+
+    def start(self):  # noqa: D401 – no-op
+        return None
+
+    async def stop(self):  # noqa: D401 – no-op
+        return None
+
+
+class _FakeBus:  # pylint: disable=too-few-public-methods
+    def async_listen_once(self, _event_type, _callback):  # noqa: D401
+        return None
+
+
+class _FakeHass:  # pylint: disable=too-few-public-methods
+    """Very small stub sufficient for *async_setup_platform*."""
+
+    def __init__(self):
+        self.loop = asyncio.get_event_loop()
+        self.bus = _FakeBus()
+
+
+# ---------------------------------------------------------------------------
+# Parametrised test cases – (ssl_flag, expected_port)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ssl_flag,expected_port",
+    [
+        (False, 8096),  # HTTP default
+        (True, 8920),  # HTTPS default
+    ],
+)
+async def test_default_port_selection(monkeypatch, ssl_flag, expected_port):  # noqa: D401
+    """Ensure the integration selects the correct default Emby port."""
+
+    from custom_components.embymedia import media_player as mp_mod
+
+    # Replace the real *pyemby.EmbyServer* with our recorder stub.
+    monkeypatch.setattr(mp_mod, "EmbyServer", _RecorderEmbyServer)
+
+    hass = _FakeHass()
+
+    config = {
+        "api_key": "ABCDEF",
+        "host": "emby.local",
+        # *No* port defined – exercise the default inference logic.
+        "ssl": ssl_flag,
+    }
+
+    # Call the coroutine under test. We do not care about entities so pass
+    # a dummy async_add_entities callable.
+    await mp_mod.async_setup_platform(hass, config, lambda _ents, update=False: None)  # type: ignore[arg-type]
+
+    # Retrieve the arguments captured by our stubbed *EmbyServer*.
+    assert _RecorderEmbyServer.last_args is not None
+    _, _, port_arg, ssl_arg, _ = _RecorderEmbyServer.last_args
+
+    # Verify that *async_setup_platform* passed the expected port and ssl
+    # parameters to the underlying Emby client.
+    assert port_arg == expected_port
+    assert ssl_arg is ssl_flag
+
+
+# ---------------------------------------------------------------------------
+# Explicit custom port should be forwarded unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_custom_port_preserved(monkeypatch):  # noqa: D401
+    """User-supplied *port* must be forwarded verbatim to EmbyServer."""
+
+    from custom_components.embymedia import media_player as mp_mod
+
+    monkeypatch.setattr(mp_mod, "EmbyServer", _RecorderEmbyServer)
+
+    hass = _FakeHass()
+
+    config = {
+        "api_key": "XYZ",
+        "host": "emby.local",
+        "port": 12345,
+        "ssl": False,
+    }
+
+    await mp_mod.async_setup_platform(hass, config, lambda _ents, update=False: None)  # type: ignore[arg-type]
+
+    assert _RecorderEmbyServer.last_args is not None
+    _, _, port_arg, _, _ = _RecorderEmbyServer.last_args
+    assert port_arg == 12345


### PR DESCRIPTION
### Summary

This PR resolves the connection regression described in #181 by updating the integration to use Emby's official default ports (8096 for HTTP, 8920 for HTTPS).

Key changes:
1. Update  and  constants in .
2. New unit‐tests  ensure that:
   * the correct default port is injected when  is omitted, depending on the  flag;
   * a user‐supplied custom port is forwarded unchanged.

All existing and new tests pass and 0 errors, 0 warnings, 0 informations  reports zero diagnostics.

### Checklist
- [x] Fix implemented
- [x] Regression tests added
- [x] ============================= test session starts ==============================
platform linux -- Python 3.13.3, pytest-8.3.5, pluggy-1.6.0
rootdir: /workspaces/homeassistant-emby
configfile: pytest.ini
plugins: cov-6.0.0, aiohttp-1.1.0, httpx-0.35.0, unordered-0.6.1, pytest_freezer-0.4.9, syrupy-4.8.1, timeout-2.3.1, sugar-1.0.0, aresponses-3.0.0, picked-0.5.1, xdist-3.6.1, socket-0.7.0, homeassistant-custom-component-0.13.252, anyio-4.9.0, github-actions-annotate-failures-0.3.0, respx-0.22.0, requests-mock-1.12.1, asyncio-0.26.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 147 items

tests/integration/emby/test_browse_media_hierarchy.py ....               [  2%]
tests/integration/emby/test_browse_media_integration.py .                [  3%]
tests/integration/emby/test_play_media_integration.py ..                 [  4%]
tests/integration/emby/test_search_media_integration.py .                [  5%]
tests/integration/emby/test_search_media_websocket.py .                  [  6%]
tests/unit/emby/test_api_helper.py ..                                    [  7%]
tests/unit/emby/test_api_helper_commands.py .............                [ 16%]
tests/unit/emby/test_api_item_cache.py .                                 [ 17%]
tests/unit/emby/test_api_library_helpers.py ..                           [ 18%]
tests/unit/emby/test_api_search_request.py ....                          [ 21%]
tests/unit/emby/test_async_get_browse_image.py ....                      [ 23%]
tests/unit/emby/test_browse_media_async.py ...                           [ 25%]
tests/unit/emby/test_browse_media_combined_param.py .                    [ 26%]
tests/unit/emby/test_browse_media_deep_tree.py .                         [ 27%]
tests/unit/emby/test_browse_media_fallback.py .                          [ 27%]
tests/unit/emby/test_browse_media_helpers.py ..............              [ 37%]
tests/unit/emby/test_browse_media_navigation.py ...                      [ 39%]
tests/unit/emby/test_browse_media_pagination_directory.py ...            [ 41%]
tests/unit/emby/test_conditional_thumbnail.py ..                         [ 42%]
tests/unit/emby/test_default_port_logic.py ...                           [ 44%]
tests/unit/emby/test_dynamic_supported_features.py .                     [ 45%]
tests/unit/emby/test_id_helpers.py .........                             [ 51%]
tests/unit/emby/test_media_player_content_properties.py ..............   [ 61%]
tests/unit/emby/test_media_player_edge_cases.py ........                 [ 66%]
tests/unit/emby/test_media_player_play_media.py ........                 [ 72%]
tests/unit/emby/test_media_player_power.py ..                            [ 73%]
tests/unit/emby/test_media_player_search.py ..                           [ 74%]
tests/unit/emby/test_media_player_setup.py .                             [ 75%]
tests/unit/emby/test_media_player_shuffle_repeat.py .......              [ 80%]
tests/unit/emby/test_media_player_volume.py ....                         [ 82%]
tests/unit/emby/test_play_media_enqueue_announce.py .....                [ 86%]
tests/unit/emby/test_search_resolver.py .........                        [ 92%]
tests/unit/emby/test_session_mapping.py ...                              [ 94%]
tests/unit/emby/test_setup_platform.py .                                 [ 95%]
tests/unit/emby/test_validation.py ......                                [ 99%]
tests/unit/test_force_full_coverage.py .                                 [100%]

============================= 147 passed in 0.56s ============================== passes ( tests)
- [x] 0 errors, 0 warnings, 0 informations  passes (0 errors / warnings)
- [x] PR assigned to @troykelly



---
*Created with Codex agent.*