### PR TITLE
fix: send proper JSON types for volume & mute (closes #195)

### DIFF
--- a/tests/unit/emby/test_api_helper_commands.py
+++ b/tests/unit/emby/test_api_helper_commands.py
@@ -52,7 +52,7 @@ async def test_set_volume_sends_correct_json(monkeypatch, input_level, expected_
 
     payload = call["json"]
     assert payload["Name"] == "VolumeSet"
-    assert payload["Arguments"]["Volume"] == str(expected_pct)
+    assert payload["Arguments"]["Volume"] == expected_pct
 
 
 # ---------------------------------------------------------------------------
@@ -61,8 +61,8 @@ async def test_set_volume_sends_correct_json(monkeypatch, input_level, expected_
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mute_flag,expected_str", [(True, "true"), (False, "false")])
-async def test_mute_command(monkeypatch, mute_flag, expected_str):
+@pytest.mark.parametrize("mute_flag", [True, False])
+async def test_mute_command(monkeypatch, mute_flag):
     recorder = _Recorder()
     api = EmbyAPI(None, host="emby", api_key="k", session=SimpleNamespace())
     monkeypatch.setattr(api, "_request", recorder)  # type: ignore[attr-defined]
@@ -71,7 +71,7 @@ async def test_mute_command(monkeypatch, mute_flag, expected_str):
 
     payload = recorder.calls[0]["json"]
     assert payload["Name"] == "Mute"
-    assert payload["Arguments"]["Mute"] == expected_str
+    assert payload["Arguments"]["Mute"] is mute_flag
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
This PR implements the runtime fix for the one-way audio control regression tracked in #190 by updating the payload types used in `EmbyAPI.set_volume` and `EmbyAPI.mute`.

#### Changes
* **custom_components/embymedia/api.py**
  *  now passes an *integer* instead of a string for the  argument.
  *  now passes a *boolean* instead of the strings "true"/"false" for the  argument.
  *  type signature widened to accept  for argument values.
* **tests/unit/emby/test_api_helper_commands.py** updated to reflect the new data types.

#### Why
Emby evaluates the **JSON value type** when processing `/Sessions/{id}/Command` requests. Supplying the numeric/boolean values wrapped as strings caused the server to ignore *un-mute* and *absolute volume* commands, leading to the behaviour described in #190.

#### Verification
* ============================= test session starts ==============================
platform linux -- Python 3.13.3, pytest-8.3.5, pluggy-1.6.0
rootdir: /workspaces/homeassistant-emby
configfile: pytest.ini
plugins: cov-6.0.0, aiohttp-1.1.0, httpx-0.35.0, unordered-0.6.1, pytest_freezer-0.4.9, syrupy-4.8.1, timeout-2.3.1, sugar-1.0.0, aresponses-3.0.0, picked-0.5.1, xdist-3.6.1, socket-0.7.0, homeassistant-custom-component-0.13.252, anyio-4.9.0, github-actions-annotate-failures-0.3.0, respx-0.22.0, requests-mock-1.12.1, asyncio-0.26.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 155 items

tests/integration/emby/test_browse_media_hierarchy.py ....               [  2%]
tests/integration/emby/test_browse_media_integration.py .                [  3%]
tests/integration/emby/test_live_connection.py ..                        [  4%]
tests/integration/emby/test_play_media_integration.py ..                 [  5%]
tests/integration/emby/test_search_media_integration.py .                [  6%]
tests/integration/emby/test_search_media_websocket.py .                  [  7%]
tests/unit/emby/test_api_helper.py ..                                    [  8%]
tests/unit/emby/test_api_helper_commands.py .............                [ 16%]
tests/unit/emby/test_api_item_cache.py .                                 [ 17%]
tests/unit/emby/test_api_library_helpers.py ..                           [ 18%]
tests/unit/emby/test_api_search_request.py ....                          [ 21%]
tests/unit/emby/test_async_get_browse_image.py ....                      [ 23%]
tests/unit/emby/test_browse_media_async.py ...                           [ 25%]
tests/unit/emby/test_browse_media_combined_param.py .                    [ 26%]
tests/unit/emby/test_browse_media_deep_tree.py .                         [ 27%]
tests/unit/emby/test_browse_media_fallback.py .                          [ 27%]
tests/unit/emby/test_browse_media_helpers.py ..............              [ 36%]
tests/unit/emby/test_browse_media_navigation.py ...                      [ 38%]
tests/unit/emby/test_browse_media_pagination_directory.py ...            [ 40%]
tests/unit/emby/test_conditional_thumbnail.py ..                         [ 41%]
tests/unit/emby/test_connection_matrix.py ......                         [ 45%]
tests/unit/emby/test_default_port_logic.py ...                           [ 47%]
tests/unit/emby/test_dynamic_supported_features.py .                     [ 48%]
tests/unit/emby/test_id_helpers.py .........                             [ 54%]
tests/unit/emby/test_media_player_content_properties.py ..............   [ 63%]
tests/unit/emby/test_media_player_edge_cases.py ........                 [ 68%]
tests/unit/emby/test_media_player_play_media.py ........                 [ 73%]
tests/unit/emby/test_media_player_power.py ..                            [ 74%]
tests/unit/emby/test_media_player_search.py ..                           [ 76%]
tests/unit/emby/test_media_player_setup.py .                             [ 76%]
tests/unit/emby/test_media_player_shuffle_repeat.py .......              [ 81%]
tests/unit/emby/test_media_player_volume.py ....                         [ 83%]
tests/unit/emby/test_play_media_enqueue_announce.py .....                [ 87%]
tests/unit/emby/test_search_resolver.py .........                        [ 92%]
tests/unit/emby/test_session_mapping.py ...                              [ 94%]
tests/unit/emby/test_setup_platform.py .                                 [ 95%]
tests/unit/emby/test_validation.py ......                                [ 99%]
tests/unit/test_force_full_coverage.py .                                 [100%]

============================= 155 passed in 2.64s ============================== – **155 passed**.
* 0 errors, 0 warnings, 0 informations  – **0 errors / 0 warnings**.

---
Closes #195
References #190