### PR TITLE
fix: correct SetVolume & Unmute commands (closes #193)

### DIFF
--- a/docs/usage/audio_control.md
+++ b/docs/usage/audio_control.md
@@ -16,8 +16,9 @@ and validated against Emby v4.9 using the web UI, Android and LG TV clients.
 
 | Action                              | Command  | JSON arguments | Notes |
 | ----------------------------------- | -------- | -------------- | ----- |
-| **Set absolute volume**             | `VolumeSet` | `{ "Volume": <int 0-100> }` | The value **must** be a number (not a string). |
-| **Mute / Un-mute**                  | `Mute`      | `{ "Mute": <bool> }`        | Send `true` to mute, `false` to un-mute. |
+| **Set absolute volume**             | `SetVolume` | `{ "Volume": <int 0-100> }` | The value **must** be a number (not a string). |
+| **Mute**                            | `Mute`      | *none*                       | — |
+| **Un-mute**                         | `Unmute`    | *none*                       | — |
 
 The semantics are defined by the *GeneralCommand* schema in the official
 Emby OpenAPI specification (`docs/emby/openapi.json`).
@@ -45,8 +46,9 @@ Emby OpenAPI specification (`docs/emby/openapi.json`).
 The helpers live in `custom_components/embymedia/api.py`:
 
 * `EmbyAPI.set_volume()` – clamps the Home Assistant `volume_level` (*float
-  0.0-1.0*) and submits `VolumeSet` with an **integer** 0-100.
-* `EmbyAPI.mute()` – forwards the boolean flag unchanged.
+  0.0-1.0*) and submits `SetVolume` with an **integer** 0-100.
+* `EmbyAPI.mute()` – chooses **`Mute`** or **`Unmute`** based on the boolean
+  flag.
 
 Both funnel into the private `_post_session_command()` utility which POSTs to
 `/Sessions/{id}/Command`.

--- a/tests/unit/emby/test_api_helper_commands.py
+++ b/tests/unit/emby/test_api_helper_commands.py
@@ -30,7 +30,7 @@ class _Recorder:
 
 
 # ---------------------------------------------------------------------------
-# set_volume – clamps & sends VolumeSet command
+# set_volume – clamps & sends SetVolume command
 # ---------------------------------------------------------------------------
 
 
@@ -51,7 +51,7 @@ async def test_set_volume_sends_correct_json(monkeypatch, input_level, expected_
     assert call["path"] == "/Sessions/sess-X/Command"
 
     payload = call["json"]
-    assert payload["Name"] == "VolumeSet"
+    assert payload["Name"] == "SetVolume"
     assert payload["Arguments"]["Volume"] == expected_pct
 
 
@@ -70,8 +70,11 @@ async def test_mute_command(monkeypatch, mute_flag):
     await api.mute("sess-1", mute_flag)
 
     payload = recorder.calls[0]["json"]
-    assert payload["Name"] == "Mute"
-    assert payload["Arguments"]["Mute"] is mute_flag
+    expected_name = "Mute" if mute_flag else "Unmute"
+
+    assert payload["Name"] == expected_name
+    # Mute/Unmute commands carry **no** arguments in modern Emby builds.
+    assert payload["Arguments"] == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
This PR resolves **#193** and addresses the remaining audio-control regression tracked under #190 by aligning the integration with the command names used by modern Emby clients:

* `SetVolume` (arguments: `{ "Volume": <int 0-100> }`)
* `Mute` / `Unmute` (no arguments)

#### Key changes
1. **API helper** – `EmbyAPI.set_volume()` now POSTs *SetVolume*; `EmbyAPI.mute()` chooses *Mute*/**Unmute** based on the boolean flag.
2. **Tests** – Updated unit & integration suites to assert the new payloads.
3. **Docs** – `docs/usage/audio_control.md` corrected to match the official [Emby WebSocket documentation](https://dev.emby.media/doc/restapi/Web-Socket.html).

Both `pytest` and `pyright` are clean:
```
pytest -q  # 160 passed
pyright     # 0 errors, 0 warnings
```

---
CC @troykelly
