### PR TITLE
fix(livetv): return TvChannel items when browsing Live TV (closes #204)

### DIFF
--- a/tests/integration/emby/test_browse_media_live_tv.py
+++ b/tests/integration/emby/test_browse_media_live_tv.py
@@ -1,0 +1,175 @@
+"""Integration test for *Live TV* browsing (GitHub issue #202).
+
+The regression surfaced when navigating into the **Live TV** view from the
+Emby media browser root – the integration incorrectly queried the generic
+`/Users/{user}/Items` endpoint which yields a list of *Artist* objects instead
+of the expected `TvChannel` items.  The fix introduces a dedicated code path
+that leverages the `/LiveTv/Channels` REST route.
+
+This test exercises the behaviour on a fully wired
+:pyclass:`custom_components.embymedia.media_player.EmbyDevice` instance with
+all outbound HTTP calls stubbed so the logic can run without an actual Emby
+server.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# HTTP stub – replaces *EmbyAPI._request*
+# ---------------------------------------------------------------------------
+
+
+class _StubHTTP:  # pylint: disable=too-few-public-methods
+    """Collect outbound REST calls and return canned JSON responses."""
+
+    def __init__(self) -> None:  # noqa: D401 – minimal container
+        self.calls: List[tuple[str, str, dict[str, Any]]] = []
+
+    async def handler(self, _self_ref, method: str, path: str, **kwargs: Any):  # noqa: D401
+        """Replacement for :pymeth:`EmbyAPI._request`."""
+
+        # Record the call so assertions can inspect later.
+        self.calls.append((method, path, kwargs))
+
+        # --------------------------------------------------------------
+        # Emby endpoints exercised by *Live TV* browse flow
+        # --------------------------------------------------------------
+
+        # Root library views
+        if path == "/Users/user-1/Views" and method == "GET":
+            return {
+                "Items": [
+                    {"Id": "lib-live", "Name": "Live TV", "CollectionType": "livetv"},
+                ]
+            }
+
+        # Attempt to resolve the view via /Items/{id} or the user scoped
+        # `/Users/{user}/Items/{id}` – Emby returns 404 for library roots so
+        # we emulate that by raising *EmbyApiError*.
+        if path in ("/Items/lib-live", "/Users/user-1/Items/lib-live") and method == "GET":
+            from custom_components.embymedia.api import EmbyApiError
+
+            raise EmbyApiError("Item not found")
+
+        # Correct endpoint for channels listing – respond with two channels
+        # so we can assert the mapping to *BrowseMedia* objects.
+        if path == "/LiveTv/Channels" and method == "GET":
+            # Verify that the caller forwarded pagination & user parameters
+            params = kwargs.get("params", {})
+            assert params.get("UserId") == "user-1"  # type: ignore[arg-type]
+
+            return {
+                "Items": [
+                    {
+                        "Id": "ch-1",
+                        "Name": "BBC One",
+                        "Type": "TvChannel",
+                        "ImageTags": {"Primary": "img1"},
+                    },
+                    {
+                        "Id": "ch-2",
+                        "Name": "CNN",
+                        "Type": "TvChannel",
+                        "ImageTags": {"Primary": "img2"},
+                    },
+                ],
+                "TotalRecordCount": 2,
+            }
+
+        raise RuntimeError(f"Unhandled EmbyAPI request {method} {path}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def http_stub(monkeypatch):
+    """Patch :pymeth:`EmbyAPI._request` globally for the duration of a test."""
+
+    from custom_components.embymedia import api as api_mod
+
+    stub = _StubHTTP()
+
+    async def _patched(self_api, method: str, path: str, **kwargs: Any):  # noqa: D401
+        return await stub.handler(self_api, method, path, **kwargs)
+
+    monkeypatch.setattr(api_mod.EmbyAPI, "_request", _patched, raising=True)
+
+    return stub
+
+
+@pytest.fixture()
+def emby_device():  # noqa: D401 – pytest naming convention
+    """Return a fully wired :class:`EmbyDevice` ready for integration tests."""
+
+    from custom_components.embymedia.media_player import EmbyDevice
+
+    dev = EmbyDevice.__new__(EmbyDevice)  # type: ignore[arg-type]
+
+    fake_device = SimpleNamespace(
+        supports_remote_control=True,
+        name="Living Room",
+        state="Idle",
+        username="john",
+        session_id="sess-123",
+        unique_id="dev1",
+        session_raw={"UserId": "user-1"},
+    )
+
+    dev.device = fake_device
+    dev.device_id = "dev1"
+
+    dev.emby = SimpleNamespace(_host="h", _api_key="k", _port=8096, _ssl=False)
+
+    # Provide attributes accessed by Home Assistant helpers.
+    dev.entity_id = "media_player.emby_living_room"  # type: ignore[attr-defined]
+    dev.async_write_ha_state = lambda *_, **__: None  # type: ignore[assignment]
+
+    return dev
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browse_live_tv_returns_channels(http_stub, emby_device):  # noqa: D401, ANN001
+    """Verify that **Live TV** browse returns *TvChannel* objects."""
+
+    from homeassistant.components.media_player.const import MediaClass
+
+    # 1. Retrieve root – required to populate the Views cache inside
+    #    *EmbyAPI* so the second call can resolve *Live TV* metadata without
+    #    hitting additional endpoints.
+    root_node = await emby_device.async_browse_media()
+
+    live_tv_node = next(child for child in root_node.children if child.title == "Live TV")  # type: ignore[arg-type]
+
+    # 2. Navigate into the Live TV container – this triggers the new helper
+    #    which queries `/LiveTv/Channels`.
+    channels_node = await emby_device.async_browse_media(
+        live_tv_node.media_content_type,
+        live_tv_node.media_content_id,
+    )
+
+    assert channels_node.children, "Expected channels list to be non-empty"  # type: ignore[arg-type]
+
+    for child in channels_node.children:  # type: ignore[arg-type]
+        assert child.media_class == MediaClass.CHANNEL  # type: ignore[attr-defined]
+
+    # Ensure the correct HTTP endpoints were invoked in order.
+    assert (
+        ("GET", "/Users/user-1/Views")
+        == http_stub.calls[0][0:2]
+    )
+    # Last call must be the channels endpoint
+    assert http_stub.calls[-1][0:2] == ("GET", "/LiveTv/Channels")


### PR DESCRIPTION
### Summary

Fixes the *Live TV* browse regression introduced in #202 where selecting **Live TV** returned *Artist* items instead of channels.

* Adds  wrapper around .
* Integrates the helper into the media browsing fallback path for *livetv* views.
* Includes a full integration test that asserts  children are returned.

All existing and new tests pass (============================= test session starts ==============================
platform linux -- Python 3.13.3, pytest-8.3.5, pluggy-1.6.0
rootdir: /workspaces/homeassistant-emby
configfile: pytest.ini
plugins: cov-6.0.0, aiohttp-1.1.0, httpx-0.35.0, unordered-0.6.1, pytest_freezer-0.4.9, syrupy-4.8.1, timeout-2.3.1, sugar-1.0.0, aresponses-3.0.0, picked-0.5.1, xdist-3.6.1, socket-0.7.0, homeassistant-custom-component-0.13.252, anyio-4.9.0, github-actions-annotate-failures-0.3.0, respx-0.22.0, requests-mock-1.12.1, asyncio-0.26.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 161 items

tests/integration/emby/test_browse_media_hierarchy.py ....               [  2%]
tests/integration/emby/test_browse_media_integration.py .                [  3%]
tests/integration/emby/test_browse_media_live_tv.py .                    [  3%]
tests/integration/emby/test_live_connection.py ..                        [  4%]
tests/integration/emby/test_play_media_integration.py ..                 [  6%]
tests/integration/emby/test_search_media_integration.py .                [  6%]
tests/integration/emby/test_search_media_websocket.py .                  [  7%]
tests/integration/emby/test_volume_mute_integration.py .....             [ 10%]
tests/unit/emby/test_api_helper.py ..                                    [ 11%]
tests/unit/emby/test_api_helper_commands.py .............                [ 19%]
tests/unit/emby/test_api_item_cache.py .                                 [ 20%]
tests/unit/emby/test_api_library_helpers.py ..                           [ 21%]
tests/unit/emby/test_api_search_request.py ....                          [ 24%]
tests/unit/emby/test_async_get_browse_image.py ....                      [ 26%]
tests/unit/emby/test_browse_media_async.py ...                           [ 28%]
tests/unit/emby/test_browse_media_combined_param.py .                    [ 29%]
tests/unit/emby/test_browse_media_deep_tree.py .                         [ 29%]
tests/unit/emby/test_browse_media_fallback.py .                          [ 30%]
tests/unit/emby/test_browse_media_helpers.py ..............              [ 39%]
tests/unit/emby/test_browse_media_navigation.py ...                      [ 40%]
tests/unit/emby/test_browse_media_pagination_directory.py ...            [ 42%]
tests/unit/emby/test_conditional_thumbnail.py ..                         [ 44%]
tests/unit/emby/test_connection_matrix.py ......                         [ 47%]
tests/unit/emby/test_default_port_logic.py ...                           [ 49%]
tests/unit/emby/test_dynamic_supported_features.py .                     [ 50%]
tests/unit/emby/test_id_helpers.py .........                             [ 55%]
tests/unit/emby/test_media_player_content_properties.py ..............   [ 64%]
tests/unit/emby/test_media_player_edge_cases.py ........                 [ 69%]
tests/unit/emby/test_media_player_play_media.py ........                 [ 74%]
tests/unit/emby/test_media_player_power.py ..                            [ 75%]
tests/unit/emby/test_media_player_search.py ..                           [ 77%]
tests/unit/emby/test_media_player_setup.py .                             [ 77%]
tests/unit/emby/test_media_player_shuffle_repeat.py .......              [ 81%]
tests/unit/emby/test_media_player_volume.py ....                         [ 84%]
tests/unit/emby/test_play_media_enqueue_announce.py .....                [ 87%]
tests/unit/emby/test_search_resolver.py .........                        [ 93%]
tests/unit/emby/test_session_mapping.py ...                              [ 95%]
tests/unit/emby/test_setup_platform.py .                                 [ 95%]
tests/unit/emby/test_validation.py ......                                [ 99%]
tests/unit/test_force_full_coverage.py .                                 [100%]

============================= 161 passed in 2.73s ==============================) and static analysis reports no issues (0 errors, 0 warnings, 0 informations ).

Closes #204, part of epic #202.
