### PR TITLE
test: cover remote control permission detection (fixes #226)

### DIFF
--- a/tests/unit/emby/test_remote_control_permission.py
+++ b/tests/unit/emby/test_remote_control_permission.py
@@ -1,0 +1,95 @@
+"""Regression tests for remote control permission detection (issue #226).
+
+These tests exercise the internal helper responsible for translating Emby
+`Session` payloads into Home Assistant *supported_features* bit-masks.  They
+cover *all* known payload shapes so that future upstream changes cannot hide
+from CI again.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# Local lightweight *pyemby.EmbyDevice* stand-in
+# ---------------------------------------------------------------------------
+
+
+class _Device(SimpleNamespace):  # noqa: D401 – minimal stub
+    """Stub replicating the relevant public attributes of *pyemby.EmbyDevice*."""
+
+    def __init__(self, session_raw: dict[str, object]):
+        # NOTE: *supports_remote_control* **must not** be present on this stub.
+        # The attribute disappeared in Emby ≥4.9 and the goal of these tests
+        # is to ensure the integration copes with its absence.
+        super().__init__(
+            name="Living room",
+            session_raw=session_raw,
+            session_id="sess-abc",
+            unique_id="dev-abc",
+            media_position=None,
+            is_nowplaying=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Small helper returning a fully wired *EmbyDevice* instance
+# ---------------------------------------------------------------------------
+
+
+def _make_emby_device(session_raw: dict[str, object]):
+    """Return an *EmbyDevice* initialised with the provided *session_raw*."""
+
+    from custom_components.embymedia.media_player import EmbyDevice
+
+    dev = EmbyDevice.__new__(EmbyDevice)  # type: ignore[arg-type]
+
+    dev.device = _Device(session_raw=session_raw)
+    dev.device_id = "dev-abc"
+    # minimal *EmbyServer* stub – only attributes accessed by the code under
+    # test are required, therefore use an in-memory namespace.
+    dev.emby = SimpleNamespace(_host="h", _api_key="k", _port=8096, _ssl=False)
+
+    # suppress Home Assistant side-effects
+    dev.async_write_ha_state = lambda *_, **__: None  # type: ignore[assignment]
+
+    # compute initial mask just like the real constructor would
+    dev._update_supported_features()  # type: ignore[attr-defined]
+
+    return dev
+
+
+# ---------------------------------------------------------------------------
+# Tests – legacy vs. new payload shapes
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_flat_flag_restores_full_feature_mask():  # noqa: D401
+    """Flat *SupportsRemoteControl* → full feature mask expected."""
+
+    from custom_components.embymedia.media_player import SUPPORT_EMBY
+
+    dev = _make_emby_device({"SupportsRemoteControl": True})
+
+    assert dev.supported_features == SUPPORT_EMBY
+
+
+def test_nested_permission_flag_restores_full_feature_mask():  # noqa: D401
+    """Nested *HasPermission.RemoteControl* → full feature mask expected."""
+
+    from custom_components.embymedia.media_player import SUPPORT_EMBY
+
+    dev = _make_emby_device({"HasPermission": {"RemoteControl": True}})
+
+    assert dev.supported_features == SUPPORT_EMBY
+
+
+def test_absent_permission_drops_all_features():  # noqa: D401
+    """Missing permission flag → no media player features exposed."""
+
+    from custom_components.embymedia.media_player import MediaPlayerEntityFeature
+
+    dev = _make_emby_device({})
+
+    assert dev.supported_features == MediaPlayerEntityFeature(0)


### PR DESCRIPTION
## Summary

Adds regression tests that exercise the three known *Session* payload variants so CI can detect breaks in remote-control capability detection.

### New tests
1. **Legacy flag** – `SupportsRemoteControl = true`
2. **Nested permissions** – `HasPermission.RemoteControl = true`
3. **No permission** – feature mask collapses to `0`

The suite would have failed on `main` prior to the Emby 4.9 compatibility patch, therefore closing the coverage gap found in #226.

---

*Closes #226*
