### PR TITLE
fix(media-source): enable artist browsing to show albums

### DIFF
--- a/custom_components/embymedia/media_source.py
+++ b/custom_components/embymedia/media_source.py
@@ -1815,6 +1815,14 @@ class EmbyMediaSource(MediaSource):  # type: ignore[misc]
                 for episode in result.get("Items", []):
                     ep_browse = self._item_to_browse_media_source(coordinator, episode)
                     children.append(ep_browse)
+            elif content_type == "artist":
+                # Get albums for this artist
+                albums = await coordinator.client.async_get_artist_albums(user_id, item_id)
+                for album in albums:
+                    album_browse = self._item_to_browse_media_source(
+                        coordinator, album, content_type="album"
+                    )
+                    children.append(album_browse)
             else:
                 # Generic fallback for folders and other expandable types
                 result = await coordinator.client.async_get_items(
@@ -1860,7 +1868,14 @@ class EmbyMediaSource(MediaSource):  # type: ignore[misc]
             content_type = item_type
 
         can_play = item_type in ("movie", "episode", "audio", "musicvideo", "tvchannel")
-        can_expand = item_type in ("series", "season", "album", "folder")
+        can_expand = item_type in (
+            "series",
+            "season",
+            "album",
+            "musicalbum",
+            "folder",
+            "musicartist",
+        )
 
         media_class = self._get_media_class_for_type(item_type)
         media_content_type = MediaType.MUSIC if item_type in ("audio", "album") else MediaType.VIDEO


### PR DESCRIPTION
## Summary

- Fixes bug where clicking on an artist in media browser attempted playback instead of showing albums
- Add `musicartist` and `musicalbum` to expandable types so they can be navigated
- Add `artist` content type handler to fetch albums via `async_get_artist_albums` API

## Problem

In v0.2.1, navigating to **Media → Emby → Server Name → Music → Artists → A → ABBA** would attempt to play something instead of showing the artist's albums/tracks.

## Root Cause

1. `_item_to_browse_media_source` was missing `musicartist` and `musicalbum` in the `can_expand` tuple
2. `_async_browse_item` had no handler for the `artist` content type

## Test plan

- [x] Added tests for artist browsing showing albums
- [x] Added tests for no user_id edge case
- [x] All 980 existing tests pass
- [ ] Manual testing: Navigate Media → Emby → Music → Artists → select artist → verify albums shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)