### PR TITLE
feat(platforms): add PARALLEL_UPDATES constant to all entity platforms (#296)

### DIFF
--- a/custom_components/embymedia/binary_sensor.py
+++ b/custom_components/embymedia/binary_sensor.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Binary sensors are read-only and use coordinators for updates
+# Value of 0 means no limit - coordinator handles update synchronization
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/embymedia/button.py
+++ b/custom_components/embymedia/button.py
@@ -49,6 +49,11 @@ if TYPE_CHECKING:
     from .coordinator import EmbyDataUpdateCoordinator
     from .coordinator_sensors import EmbyServerCoordinator
 
+# Limit concurrent button presses to prevent overwhelming the Emby server
+# Value of 1 means only one press action at a time per entity
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 1
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/embymedia/image.py
+++ b/custom_components/embymedia/image.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Image entities are read-only and use coordinators for updates
+# Value of 0 means no limit - coordinator handles update synchronization
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/embymedia/media_player.py
+++ b/custom_components/embymedia/media_player.py
@@ -45,6 +45,11 @@ from .coordinator import EmbyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# Limit concurrent service calls to prevent overwhelming the Emby server
+# Value of 1 means only one service action at a time per entity
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 1
+
 # Map Emby media types to HA media types
 _MEDIA_TYPE_MAP: dict[EmbyMediaType, MediaType] = {
     EmbyMediaType.MOVIE: MediaType.MOVIE,

--- a/custom_components/embymedia/notify.py
+++ b/custom_components/embymedia/notify.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Limit concurrent notification sends to prevent overwhelming the Emby server
+# Value of 1 means only one send_message action at a time per entity
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/embymedia/remote.py
+++ b/custom_components/embymedia/remote.py
@@ -71,6 +71,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Limit concurrent remote commands to prevent overwhelming the Emby server
+# Value of 1 means only one send_command action at a time per entity
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/embymedia/sensor.py
+++ b/custom_components/embymedia/sensor.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sensors are read-only and use coordinators for updates
+# Value of 0 means no limit - coordinator handles update synchronization
+# This is required for Home Assistant Integration Quality Scale Silver tier
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/tests/test_parallel_updates.py
+++ b/tests/test_parallel_updates.py
@@ -1,0 +1,67 @@
+"""Tests for PARALLEL_UPDATES constant on all platforms (Issue #296).
+
+These tests verify that all entity platforms define PARALLEL_UPDATES
+to comply with Home Assistant Integration Quality Scale Silver tier.
+"""
+
+from __future__ import annotations
+
+
+class TestPlatformParallelUpdates:
+    """Tests for PARALLEL_UPDATES on all platform modules."""
+
+    def test_media_player_has_parallel_updates(self) -> None:
+        """Test that media_player.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import media_player
+
+        assert hasattr(media_player, "PARALLEL_UPDATES")
+        # media_player has service actions, so should be limited
+        assert media_player.PARALLEL_UPDATES == 1
+
+    def test_sensor_has_parallel_updates(self) -> None:
+        """Test that sensor.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import sensor
+
+        assert hasattr(sensor, "PARALLEL_UPDATES")
+        # sensor is read-only, coordinator handles updates
+        assert sensor.PARALLEL_UPDATES == 0
+
+    def test_binary_sensor_has_parallel_updates(self) -> None:
+        """Test that binary_sensor.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import binary_sensor
+
+        assert hasattr(binary_sensor, "PARALLEL_UPDATES")
+        # binary_sensor is read-only, coordinator handles updates
+        assert binary_sensor.PARALLEL_UPDATES == 0
+
+    def test_button_has_parallel_updates(self) -> None:
+        """Test that button.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import button
+
+        assert hasattr(button, "PARALLEL_UPDATES")
+        # button has press action, should be limited
+        assert button.PARALLEL_UPDATES == 1
+
+    def test_remote_has_parallel_updates(self) -> None:
+        """Test that remote.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import remote
+
+        assert hasattr(remote, "PARALLEL_UPDATES")
+        # remote has navigation commands, should be limited
+        assert remote.PARALLEL_UPDATES == 1
+
+    def test_image_has_parallel_updates(self) -> None:
+        """Test that image.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import image
+
+        assert hasattr(image, "PARALLEL_UPDATES")
+        # image is read-only, coordinator handles updates
+        assert image.PARALLEL_UPDATES == 0
+
+    def test_notify_has_parallel_updates(self) -> None:
+        """Test that notify.py has PARALLEL_UPDATES defined."""
+        from custom_components.embymedia import notify
+
+        assert hasattr(notify, "PARALLEL_UPDATES")
+        # notify has send message action, should be limited
+        assert notify.PARALLEL_UPDATES == 1


### PR DESCRIPTION
## Summary

Adds `PARALLEL_UPDATES` constant to all entity platforms per [Home Assistant Integration Quality Scale Silver tier requirements](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/).

### Read-only platforms (PARALLEL_UPDATES = 0):
- **sensor** - coordinator handles updates
- **binary_sensor** - coordinator handles updates  
- **image** - coordinator handles updates

### Action platforms (PARALLEL_UPDATES = 1):
- **media_player** - has play/pause/volume actions
- **button** - has press actions (library refresh)
- **remote** - has navigation command actions
- **notify** - has send_message actions

Setting `PARALLEL_UPDATES = 1` for action platforms prevents overwhelming the Emby server when multiple entities trigger actions concurrently.

## Test plan

- [x] Added tests verifying all 7 platforms have `PARALLEL_UPDATES` defined
- [x] Added tests verifying read-only platforms use `0`
- [x] Added tests verifying action platforms use `1`
- [x] All 1741 tests pass

## Related Issues

Fixes #296
Part of Epic #286 (Efficiency Audit - 2026 Best Practices)

---
🤖 Generated with [Claude Code](https://claude.ai/code)