### PR TITLE
fix(tests): update test mocks for batch user counts API (#291)

### DIFF
--- a/tests/test_always_update_false.py
+++ b/tests/test_always_update_false.py
@@ -59,6 +59,7 @@ class TestEmbyServerCoordinatorAlwaysUpdate:
 
         mock_client = MagicMock()
         mock_entry = MagicMock()
+        mock_entry.options = {}
 
         coordinator = EmbyServerCoordinator(
             hass=hass,
@@ -87,6 +88,7 @@ class TestEmbyLibraryCoordinatorAlwaysUpdate:
 
         mock_client = MagicMock()
         mock_entry = MagicMock()
+        mock_entry.options = {}
 
         coordinator = EmbyLibraryCoordinator(
             hass=hass,

--- a/tests/test_configurable_polling.py
+++ b/tests/test_configurable_polling.py
@@ -9,7 +9,7 @@ These tests verify that:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -77,7 +77,7 @@ class TestOptionsFlowPollingIntervals:
         # Verify form is shown with library interval field
         assert result["type"] == "form"
         schema = result["data_schema"]
-        schema_keys = [str(k) for k in schema.schema.keys()]
+        schema_keys = [str(k) for k in schema.schema]
         assert CONF_LIBRARY_SCAN_INTERVAL in schema_keys
 
     @pytest.mark.asyncio
@@ -105,7 +105,7 @@ class TestOptionsFlowPollingIntervals:
         # Verify form is shown with server interval field
         assert result["type"] == "form"
         schema = result["data_schema"]
-        schema_keys = [str(k) for k in schema.schema.keys()]
+        schema_keys = [str(k) for k in schema.schema]
         assert CONF_SERVER_SCAN_INTERVAL in schema_keys
 
     @pytest.mark.asyncio

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -34,6 +34,15 @@ def mock_client() -> MagicMock:
     client.async_get_suggestions = AsyncMock(return_value=[])
     client.async_get_user_item_count = AsyncMock(return_value=0)
     client.async_get_playlists = AsyncMock(return_value=[])
+    # Batch user counts method added in Issue #291
+    client.async_get_all_user_counts = AsyncMock(
+        return_value={
+            "favorites_count": 0,
+            "played_count": 0,
+            "resumable_count": 0,
+            "playlist_count": 0,
+        }
+    )
     return client
 
 


### PR DESCRIPTION
## Summary

Update test fixtures to work with the new `async_get_all_user_counts()` batch method added in Issue #291.

### Changes

- **test_discovery_cache.py**: Add `async_get_all_user_counts` mock to fixture returning `UserCountsResult` with all four count fields
- **test_always_update_false.py**: Add `mock_entry.options = {}` to prevent TypeError when coordinators access scan_interval options
- **test_configurable_polling.py**: Remove unused import, use idiomatic dict iteration (ruff SIM118)

### Context

After merging PRs #301-#304 from Epic #286, the test suite had 14 failures due to:
1. Missing mock for the new `async_get_all_user_counts()` batch method
2. Mock config entries returning MagicMock instead of dict for `.options`

All 1861 tests now pass.

## Test plan

- [x] Run full test suite: `pytest tests/ -q`
- [x] Run lint checks: `ruff check`
- [x] Run type checks: `mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)