### PR TITLE
[#323] Use async_create_background_task for long-running coordinator tasks

### DIFF
--- a/custom_components/embymedia/coordinator.py
+++ b/custom_components/embymedia/coordinator.py
@@ -287,7 +287,9 @@ class EmbyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, EmbySession]]):
                 if self._polling_disabled:
                     await self.async_health_check()
 
-        self._health_check_task = self.hass.async_create_task(_health_check_loop())
+        self._health_check_task = self.config_entry.async_create_background_task(
+            self.hass, _health_check_loop(), f"{self.name}_health_check"
+        )
 
     async def async_health_check(self) -> None:
         """Perform a lightweight health check.
@@ -674,8 +676,10 @@ class EmbyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, EmbySession]]):
             # Notify library coordinator to extend its polling interval (#289)
             self._update_library_coordinator_websocket_status(True)
             # Start receive loop in background and store task for cleanup
-            self._websocket_receive_task = self.hass.async_create_task(
-                self._async_websocket_receive_loop()
+            self._websocket_receive_task = self.config_entry.async_create_background_task(
+                self.hass,
+                self._async_websocket_receive_loop(),
+                f"{self.name}_ws_receive",
             )
         except aiohttp.ClientError as err:
             _LOGGER.warning(

--- a/tests/test_image_discovery.py
+++ b/tests/test_image_discovery.py
@@ -63,11 +63,9 @@ def mock_coordinator_with_data() -> MagicMock:
     coordinator.last_update_success = True
     coordinator.client = MagicMock()
     coordinator.client.get_image_url = MagicMock(
-        side_effect=lambda item_id,
-        image_type="Primary",
-        max_width=None,
-        max_height=None,
-        tag=None: f"https://emby.local/Items/{item_id}/Images/{image_type}?tag={tag}"
+        side_effect=lambda item_id, image_type="Primary", max_width=None, max_height=None, tag=None: (
+            f"https://emby.local/Items/{item_id}/Images/{image_type}?tag={tag}"
+        )
     )
     coordinator.data = EmbyDiscoveryData(
         next_up=[

--- a/tests/test_sensor_discovery.py
+++ b/tests/test_sensor_discovery.py
@@ -33,11 +33,9 @@ def mock_client() -> MagicMock:
     """Create a mock Emby client."""
     client = MagicMock()
     client.get_image_url = MagicMock(
-        side_effect=lambda item_id,
-        image_type="Primary",
-        max_width=None,
-        max_height=None,
-        tag=None: f"https://emby.local/Items/{item_id}/Images/{image_type}"
+        side_effect=lambda item_id, image_type="Primary", max_width=None, max_height=None, tag=None: (
+            f"https://emby.local/Items/{item_id}/Images/{image_type}"
+        )
     )
     return client
 

--- a/tests/test_websocket_polling_optimization.py
+++ b/tests/test_websocket_polling_optimization.py
@@ -464,11 +464,16 @@ class TestAdditionalCoverage:
         # Get to stable state and start the health check loop
         coordinator._polling_disabled = True
 
-        # Patch asyncio.sleep to return immediately
-        with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Patch asyncio.sleep in the coordinator module to return immediately
+        with patch(
+            "custom_components.embymedia.coordinator.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
             coordinator._schedule_health_check()
-            # Give the task a chance to run
-            await asyncio.sleep(0.01)
+            # Give the background task a chance to run through event loop iterations
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
 
         assert health_check_called is True
 

--- a/tests/test_websocket_polling_optimization.py
+++ b/tests/test_websocket_polling_optimization.py
@@ -442,6 +442,11 @@ class TestAdditionalCoverage:
         import asyncio
         from unittest.mock import patch
 
+        # Make async_create_background_task actually create real asyncio tasks
+        mock_config_entry.async_create_background_task = lambda _hass, coro, name, **kw: (
+            asyncio.ensure_future(coro)
+        )
+
         coordinator = EmbyDataUpdateCoordinator(
             hass=hass,
             client=mock_client,

--- a/tests/test_websocket_polling_optimization.py
+++ b/tests/test_websocket_polling_optimization.py
@@ -439,13 +439,18 @@ class TestAdditionalCoverage:
         self, hass: HomeAssistant, mock_client: MagicMock, mock_config_entry: MagicMock
     ) -> None:
         """Test that the health check loop actually runs and calls health check."""
-        import asyncio
+        from typing import Any
         from unittest.mock import patch
 
-        # Make async_create_background_task actually create real asyncio tasks
-        mock_config_entry.async_create_background_task = lambda _hass, coro, name, **kw: (
-            asyncio.ensure_future(coro)
-        )
+        # Capture the coroutine passed to async_create_background_task
+        captured_coro = None
+
+        def capture_background_task(_hass: Any, coro: Any, name: str, **kw: Any) -> MagicMock:
+            nonlocal captured_coro
+            captured_coro = coro
+            return MagicMock()
+
+        mock_config_entry.async_create_background_task = capture_background_task
 
         coordinator = EmbyDataUpdateCoordinator(
             hass=hass,
@@ -475,10 +480,9 @@ class TestAdditionalCoverage:
             new_callable=AsyncMock,
         ):
             coordinator._schedule_health_check()
-            # Give the background task a chance to run through event loop iterations
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
+            # Run the captured coroutine directly instead of relying on event loop scheduling
+            assert captured_coro is not None
+            await captured_coro
 
         assert health_check_called is True
 


### PR DESCRIPTION
## Summary
Replace `hass.async_create_task()` with `config_entry.async_create_background_task()` for long-running background tasks in the coordinator. This prevents these tasks from blocking Home Assistant startup and ensures proper lifecycle management tied to the config entry.

## Changes
- **`_schedule_health_check()`**: Use `async_create_background_task` with name `{name}_health_check`
- **`async_setup_websocket()`**: Use `async_create_background_task` with name `{name}_ws_receive`

## Why
Using `hass.async_create_task()` for long-running loops can cause Home Assistant startup to be blocked waiting for these tasks. The `async_create_background_task()` method properly registers these as background tasks that don't block startup and are automatically cancelled when the config entry is unloaded.

## Test Results
- 819 tests passed
- 1 pre-existing test failure in `test_device_condition.py` (unrelated entity ID naming issue)

Fixes #323