### PR TITLE
Add media stream codec, channel layout, and display title attributes

### DIFF
--- a/custom_components/embymedia/const.py
+++ b/custom_components/embymedia/const.py
@@ -327,6 +327,7 @@ class EmbyNowPlayingItem(TypedDict):
     BackdropImageTags: NotRequired[list[str]]
     ParentBackdropImageTags: NotRequired[list[str]]
     MediaType: NotRequired[str]  # "Video", "Audio"
+    MediaStreams: NotRequired[list[dict[str, object]]]  # Codec, DisplayTitle, etc.
 
 
 class EmbyPlayState(TypedDict):

--- a/custom_components/embymedia/media_player.py
+++ b/custom_components/embymedia/media_player.py
@@ -430,6 +430,78 @@ class EmbyMediaPlayer(EmbyEntity, MediaPlayerEntity):
         return session.play_state.is_muted
 
     @property
+    def media_type_raw(self) -> str | None:
+        """Return the raw Emby media type (e.g. "Movie", "Audio").
+
+        Returns:
+            Raw type string or None if not playing.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.media_type_raw
+
+    @property
+    def video_codec(self) -> str | None:
+        """Return the video codec from the currently playing item.
+
+        Returns:
+            Codec string or None if not playing or no video stream.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.video_codec
+
+    @property
+    def video_display_title(self) -> str | None:
+        """Return the video display title from the currently playing item.
+
+        Returns:
+            Display title string or None if not playing or no video stream.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.video_display_title
+
+    @property
+    def audio_codec(self) -> str | None:
+        """Return the audio codec from the currently playing item.
+
+        Returns:
+            Codec string or None if not playing or no audio stream.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.audio_codec
+
+    @property
+    def audio_channel_layout(self) -> str | None:
+        """Return the audio channel layout from the currently playing item.
+
+        Returns:
+            Channel layout string or None if not playing or no audio stream.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.audio_channel_layout
+
+    @property
+    def audio_display_title(self) -> str | None:
+        """Return the audio display title from the currently playing item.
+
+        Returns:
+            Display title string or None if not playing or no audio stream.
+        """
+        session = self.session
+        if session is None or session.now_playing is None:
+            return None
+        return session.now_playing.audio_display_title
+
+    @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Return entity specific state attributes.
 

--- a/custom_components/embymedia/models.py
+++ b/custom_components/embymedia/models.py
@@ -30,6 +30,26 @@ class MediaType(StrEnum):
 
 
 @dataclass(frozen=True, slots=True)
+class EmbyMediaStream:
+    """A single media stream within a playing item.
+
+    Represents a video, audio, or subtitle stream from the Emby
+    MediaStreams array in the NowPlayingItem session data.
+
+    Attributes:
+        type: Stream type ("Video", "Audio", "Subtitle").
+        codec: Codec name (e.g. "hevc", "truehd", "aac"), or None.
+        channel_layout: Audio channel layout (e.g. "5.1", "7.1"), or None.
+        display_title: Human-readable display title from Emby, or None.
+    """
+
+    type: str
+    codec: str | None = None
+    channel_layout: str | None = None
+    display_title: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class EmbyMediaItem:
     """Currently playing media item.
 
@@ -55,6 +75,7 @@ class EmbyMediaItem:
         season_id: ID of the parent season (for episodes) for image fallback.
         album_id: ID of the parent album (for audio) for image fallback.
         parent_backdrop_image_tags: Tuple of backdrop image tags from parent.
+        media_streams: Tuple of EmbyMediaStream instances parsed from API.
     """
 
     item_id: str
@@ -75,6 +96,90 @@ class EmbyMediaItem:
     season_id: str | None = None
     album_id: str | None = None
     parent_backdrop_image_tags: tuple[str, ...] = field(default_factory=tuple)
+    media_streams: tuple[EmbyMediaStream, ...] = field(default_factory=tuple)
+
+    @property
+    def media_type_raw(self) -> str:
+        """Return the raw Emby media type string.
+
+        Returns:
+            The string value of the media_type enum (e.g. "Movie", "Audio").
+        """
+        return self.media_type.value
+
+    @property
+    def video_stream(self) -> EmbyMediaStream | None:
+        """Return the first video stream, or None if not found.
+
+        Returns:
+            The first EmbyMediaStream with type "Video", or None.
+        """
+        for stream in self.media_streams:
+            if stream.type == "Video":
+                return stream
+        return None
+
+    @property
+    def audio_stream(self) -> EmbyMediaStream | None:
+        """Return the first audio stream, or None if not found.
+
+        Returns:
+            The first EmbyMediaStream with type "Audio", or None.
+        """
+        for stream in self.media_streams:
+            if stream.type == "Audio":
+                return stream
+        return None
+
+    @property
+    def video_codec(self) -> str | None:
+        """Return the video codec from the first video stream.
+
+        Returns:
+            Codec string or None if no video stream.
+        """
+        stream = self.video_stream
+        return stream.codec if stream else None
+
+    @property
+    def video_display_title(self) -> str | None:
+        """Return the video display title from the first video stream.
+
+        Returns:
+            Display title string or None if no video stream.
+        """
+        stream = self.video_stream
+        return stream.display_title if stream else None
+
+    @property
+    def audio_codec(self) -> str | None:
+        """Return the audio codec from the first audio stream.
+
+        Returns:
+            Codec string or None if no audio stream.
+        """
+        stream = self.audio_stream
+        return stream.codec if stream else None
+
+    @property
+    def audio_channel_layout(self) -> str | None:
+        """Return the audio channel layout from the first audio stream.
+
+        Returns:
+            Channel layout string or None if no audio stream.
+        """
+        stream = self.audio_stream
+        return stream.channel_layout if stream else None
+
+    @property
+    def audio_display_title(self) -> str | None:
+        """Return the audio display title from the first audio stream.
+
+        Returns:
+            Display title string or None if no audio stream.
+        """
+        stream = self.audio_stream
+        return stream.display_title if stream else None
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,6 +315,27 @@ def parse_media_item(data: EmbyNowPlayingItem) -> EmbyMediaItem:
 
     parent_backdrop_tags = data.get("ParentBackdropImageTags", [])
 
+    media_streams_data = data.get("MediaStreams", [])
+    media_streams: tuple[EmbyMediaStream, ...] = ()
+    if media_streams_data:
+        parsed_streams: list[EmbyMediaStream] = []
+        for stream in media_streams_data:
+            raw_type = stream.get("Type")
+            if not isinstance(raw_type, str):
+                continue
+            raw_codec = stream.get("Codec")
+            raw_layout = stream.get("ChannelLayout")
+            raw_title = stream.get("DisplayTitle")
+            parsed_streams.append(
+                EmbyMediaStream(
+                    type=raw_type,
+                    codec=str(raw_codec) if isinstance(raw_codec, str) else None,
+                    channel_layout=str(raw_layout) if isinstance(raw_layout, str) else None,
+                    display_title=str(raw_title) if isinstance(raw_title, str) else None,
+                )
+            )
+        media_streams = tuple(parsed_streams)
+
     return EmbyMediaItem(
         item_id=data["Id"],
         name=data["Name"],
@@ -229,6 +355,7 @@ def parse_media_item(data: EmbyNowPlayingItem) -> EmbyMediaItem:
         season_id=data.get("SeasonId"),
         album_id=data.get("AlbumId"),
         parent_backdrop_image_tags=tuple(parent_backdrop_tags),
+        media_streams=media_streams,
     )
 
 
@@ -307,6 +434,7 @@ def parse_session(data: EmbySessionResponse) -> EmbySession:
 
 __all__ = [
     "EmbyMediaItem",
+    "EmbyMediaStream",
     "EmbyPlaybackState",
     "EmbySession",
     "MediaType",

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -2503,3 +2503,297 @@ class TestSimilarItemsAttribute:
         # Cache should be cleared due to error
         assert player._similar_items_cache is None
         assert player._similar_items_item_id is None
+
+
+class TestMediaStreamAttributes:
+    """Test media stream attribute properties on EmbyMediaPlayer."""
+
+    def test_video_codec_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_codec returns codec from session now_playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Video", codec="hevc"),),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.video_codec == "hevc"
+
+    def test_video_codec_when_no_video_stream(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_codec returns None when no video stream."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.AUDIO,
+            media_streams=(EmbyMediaStream(type="Audio", codec="aac"),),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.video_codec is None
+
+    def test_video_codec_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_codec returns None when session not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.video_codec is None
+
+    def test_video_codec_when_no_session(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_codec returns None when no session."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        mock_coordinator.get_session.return_value = None
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-xyz")
+        assert player.video_codec is None
+
+    def test_video_display_title_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_display_title returns display title from session."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(
+                EmbyMediaStream(type="Video", display_title="HEVC Main 10 HDR"),
+            ),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.video_display_title == "HEVC Main 10 HDR"
+
+    def test_video_display_title_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test video_display_title returns None when not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.video_display_title is None
+
+    def test_audio_codec_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_codec returns codec from session now_playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Audio", codec="truehd"),),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_codec == "truehd"
+
+    def test_audio_codec_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_codec returns None when not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_codec is None
+
+    def test_audio_channel_layout_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_channel_layout returns layout from session."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Audio", channel_layout="5.1"),),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_channel_layout == "5.1"
+
+    def test_audio_channel_layout_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_channel_layout returns None when not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_channel_layout is None
+
+    def test_audio_display_title_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_display_title returns display title from session."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(
+                EmbyMediaStream(type="Audio", display_title="Dolby TrueHD 7.1"),
+            ),
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_display_title == "Dolby TrueHD 7.1"
+
+    def test_audio_display_title_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test audio_display_title returns None when not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.audio_display_title is None
+
+    def test_media_type_raw_when_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test media_type_raw returns raw type string."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+        from custom_components.embymedia.models import EmbyMediaItem, MediaType
+
+        session = MagicMock()
+        session.now_playing = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+        )
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.media_type_raw == "Movie"
+
+    def test_media_type_raw_when_not_playing(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test media_type_raw returns None when not playing."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        session = MagicMock()
+        session.now_playing = None
+        mock_coordinator.get_session.return_value = session
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-abc")
+        assert player.media_type_raw is None
+
+    def test_media_type_raw_when_no_session(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Test media_type_raw returns None when no session."""
+        from custom_components.embymedia.media_player import EmbyMediaPlayer
+
+        mock_coordinator.get_session.return_value = None
+
+        player = EmbyMediaPlayer(mock_coordinator, "device-xyz")
+        assert player.media_type_raw is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -696,3 +696,406 @@ class TestQueueDataInSession:
         session = parse_session(data)
         assert session.queue_item_ids == ("item1", "item2")
         assert session.queue_position == 0  # Default to 0 when not found
+
+
+class TestEmbyMediaStream:
+    """Test EmbyMediaStream dataclass."""
+
+    def test_creation_minimal(self) -> None:
+        """Test creating EmbyMediaStream with only type."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(type="Video")
+        assert stream.type == "Video"
+        assert stream.codec is None
+        assert stream.channel_layout is None
+        assert stream.display_title is None
+
+    def test_creation_full(self) -> None:
+        """Test creating EmbyMediaStream with all fields."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(
+            type="Audio",
+            codec="ac3",
+            channel_layout="5.1",
+            display_title="Dolby Digital 5.1",
+        )
+        assert stream.type == "Audio"
+        assert stream.codec == "ac3"
+        assert stream.channel_layout == "5.1"
+        assert stream.display_title == "Dolby Digital 5.1"
+
+    def test_frozen(self) -> None:
+        """Test EmbyMediaStream is immutable."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(type="Video")
+        with pytest.raises(AttributeError):
+            stream.type = "Audio"  # type: ignore[misc]
+
+    def test_default_codec_none(self) -> None:
+        """Test codec defaults to None."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(type="Video")
+        assert stream.codec is None
+
+    def test_default_channel_layout_none(self) -> None:
+        """Test channel_layout defaults to None."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(type="Video")
+        assert stream.channel_layout is None
+
+    def test_default_display_title_none(self) -> None:
+        """Test display_title defaults to None."""
+        from custom_components.embymedia.models import EmbyMediaStream
+
+        stream = EmbyMediaStream(type="Video")
+        assert stream.display_title is None
+
+
+class TestEmbyMediaItemStreamProperties:
+    """Test EmbyMediaItem media stream properties."""
+
+    def test_media_type_raw_movie(self) -> None:
+        """Test media_type_raw returns Movie string."""
+        from custom_components.embymedia.models import EmbyMediaItem, MediaType
+
+        item = EmbyMediaItem(item_id="id", name="test", media_type=MediaType.MOVIE)
+        assert item.media_type_raw == "Movie"
+
+    def test_media_type_raw_audio(self) -> None:
+        """Test media_type_raw returns Audio string."""
+        from custom_components.embymedia.models import EmbyMediaItem, MediaType
+
+        item = EmbyMediaItem(item_id="id", name="test", media_type=MediaType.AUDIO)
+        assert item.media_type_raw == "Audio"
+
+    def test_media_type_raw_unknown(self) -> None:
+        """Test media_type_raw returns Unknown string."""
+        from custom_components.embymedia.models import EmbyMediaItem, MediaType
+
+        item = EmbyMediaItem(item_id="id", name="test", media_type=MediaType.UNKNOWN)
+        assert item.media_type_raw == "Unknown"
+
+    def test_video_codec_when_video_stream_exists(self) -> None:
+        """Test video_codec returns codec from first video stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Video", codec="hevc"),),
+        )
+        assert item.video_codec == "hevc"
+
+    def test_video_codec_when_no_video_stream(self) -> None:
+        """Test video_codec returns None when no video stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Audio", codec="aac"),),
+        )
+        assert item.video_codec is None
+
+    def test_video_codec_when_no_streams(self) -> None:
+        """Test video_codec returns None when no media streams."""
+        from custom_components.embymedia.models import EmbyMediaItem, MediaType
+
+        item = EmbyMediaItem(item_id="id", name="test", media_type=MediaType.MOVIE)
+        assert item.video_codec is None
+
+    def test_video_display_title_when_video_stream_exists(self) -> None:
+        """Test video_display_title returns display_title from first video stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(
+                EmbyMediaStream(type="Video", display_title="HEVC Main 10 HDR"),
+            ),
+        )
+        assert item.video_display_title == "HEVC Main 10 HDR"
+
+    def test_video_display_title_when_no_video_stream(self) -> None:
+        """Test video_display_title returns None when no video stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(),
+        )
+        assert item.video_display_title is None
+
+    def test_audio_codec_when_audio_stream_exists(self) -> None:
+        """Test audio_codec returns codec from first audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Audio", codec="truehd"),),
+        )
+        assert item.audio_codec == "truehd"
+
+    def test_audio_codec_when_no_audio_stream(self) -> None:
+        """Test audio_codec returns None when no audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Video", codec="hevc"),),
+        )
+        assert item.audio_codec is None
+
+    def test_audio_channel_layout_when_audio_stream_exists(self) -> None:
+        """Test audio_channel_layout returns layout from first audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Audio", channel_layout="7.1"),),
+        )
+        assert item.audio_channel_layout == "7.1"
+
+    def test_audio_channel_layout_when_no_audio_stream(self) -> None:
+        """Test audio_channel_layout returns None when no audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(),
+        )
+        assert item.audio_channel_layout is None
+
+    def test_audio_display_title_when_audio_stream_exists(self) -> None:
+        """Test audio_display_title returns display_title from first audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(
+                EmbyMediaStream(type="Audio", display_title="Dolby TrueHD 7.1"),
+            ),
+        )
+        assert item.audio_display_title == "Dolby TrueHD 7.1"
+
+    def test_audio_display_title_when_no_audio_stream(self) -> None:
+        """Test audio_display_title returns None when no audio stream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(),
+        )
+        assert item.audio_display_title is None
+
+    def test_video_stream_returns_first_video(self) -> None:
+        """Test video_stream returns the first video-type EmbyMediaStream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        video1 = EmbyMediaStream(type="Video", codec="h264")
+        video2 = EmbyMediaStream(type="Video", codec="hevc")
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(video1, video2),
+        )
+        assert item.video_stream is video1
+
+    def test_video_stream_when_no_video(self) -> None:
+        """Test video_stream returns None when no video streams."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.AUDIO,
+            media_streams=(EmbyMediaStream(type="Audio", codec="aac"),),
+        )
+        assert item.video_stream is None
+
+    def test_audio_stream_returns_first_audio(self) -> None:
+        """Test audio_stream returns the first audio-type EmbyMediaStream."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        audio1 = EmbyMediaStream(type="Audio", codec="ac3")
+        audio2 = EmbyMediaStream(type="Audio", codec="truehd")
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(audio1, audio2),
+        )
+        assert item.audio_stream is audio1
+
+    def test_audio_stream_when_no_audio(self) -> None:
+        """Test audio_stream returns None when no audio streams."""
+        from custom_components.embymedia.models import (
+            EmbyMediaItem,
+            EmbyMediaStream,
+            MediaType,
+        )
+
+        item = EmbyMediaItem(
+            item_id="id",
+            name="test",
+            media_type=MediaType.MOVIE,
+            media_streams=(EmbyMediaStream(type="Video", codec="hevc"),),
+        )
+        assert item.audio_stream is None
+
+
+class TestParseMediaItemMediaStreams:
+    """Test parse_media_item with MediaStreams."""
+
+    def test_parse_with_media_streams(self) -> None:
+        """Test parsing item with MediaStreams array."""
+        from custom_components.embymedia.const import EmbyNowPlayingItem
+        from custom_components.embymedia.models import parse_media_item
+
+        data: EmbyNowPlayingItem = {
+            "Id": "item-123",
+            "Name": "Test Movie",
+            "Type": "Movie",
+            "MediaStreams": [
+                {
+                    "Type": "Video",
+                    "Codec": "hevc",
+                    "DisplayTitle": "HEVC Main 10 HDR",
+                },
+                {
+                    "Type": "Audio",
+                    "Codec": "truehd",
+                    "ChannelLayout": "7.1",
+                    "DisplayTitle": "Dolby TrueHD 7.1",
+                },
+            ],
+        }
+        item = parse_media_item(data)
+        assert len(item.media_streams) == 2
+        assert item.media_streams[0].type == "Video"
+        assert item.media_streams[0].codec == "hevc"
+        assert item.media_streams[0].display_title == "HEVC Main 10 HDR"
+        assert item.media_streams[1].type == "Audio"
+        assert item.media_streams[1].codec == "truehd"
+        assert item.media_streams[1].channel_layout == "7.1"
+        assert item.media_streams[1].display_title == "Dolby TrueHD 7.1"
+
+    def test_parse_without_media_streams(self) -> None:
+        """Test parsing item without MediaStreams returns empty tuple."""
+        from custom_components.embymedia.const import EmbyNowPlayingItem
+        from custom_components.embymedia.models import parse_media_item
+
+        data: EmbyNowPlayingItem = {
+            "Id": "item-123",
+            "Name": "Test Movie",
+            "Type": "Movie",
+        }
+        item = parse_media_item(data)
+        assert item.media_streams == ()
+
+    def test_parse_with_empty_media_streams(self) -> None:
+        """Test parsing item with empty MediaStreams array."""
+        from custom_components.embymedia.const import EmbyNowPlayingItem
+        from custom_components.embymedia.models import parse_media_item
+
+        data: EmbyNowPlayingItem = {
+            "Id": "item-123",
+            "Name": "Test Audio",
+            "Type": "Audio",
+            "MediaStreams": [],
+        }
+        item = parse_media_item(data)
+        assert item.media_streams == ()
+
+    def test_parse_with_partial_stream_data(self) -> None:
+        """Test parsing MediaStreams with minimal fields."""
+        from custom_components.embymedia.const import EmbyNowPlayingItem
+        from custom_components.embymedia.models import parse_media_item
+
+        data: EmbyNowPlayingItem = {
+            "Id": "item-123",
+            "Name": "Test Movie",
+            "Type": "Movie",
+            "MediaStreams": [
+                {"Type": "Video"},
+            ],
+        }
+        item = parse_media_item(data)
+        assert len(item.media_streams) == 1
+        assert item.media_streams[0].type == "Video"
+        assert item.media_streams[0].codec is None
+        assert item.media_streams[0].display_title is None
+        assert item.media_streams[0].channel_layout is None


### PR DESCRIPTION
## Description

Exposes the `MediaStreams` array from the Emby "Now Playing" session data as new attributes on the media player entity.

### New attributes

| Attribute | Source | Example |
|-----------|--------|---------|
| `media_type_raw` | `NowPlayingItem.Type` | `"Movie"`, `"Audio"` |
| `video_codec` | First Video stream's `Codec` | `"hevc"`, `"h264"` |
| `video_display_title` | First Video stream's `DisplayTitle` | `"HEVC Main 10 HDR"` |
| `audio_codec` | First Audio stream's `Codec` | `"truehd"`, `"aac"` |
| `audio_channel_layout` | First Audio stream's `ChannelLayout` | `"5.1"`, `"7.1"` |
| `audio_display_title` | First Audio stream's `DisplayTitle` | `"Dolby TrueHD 7.1"` |

All attributes return `None` gracefully when no session, nothing playing, or no matching stream type.

### Implementation

- Added `MediaStreams` field to `EmbyNowPlayingItem` TypedDict (const.py)
- Added `EmbyMediaStream` frozen dataclass with `type`, `codec`, `channel_layout`, `display_title` (models.py)
- Added `media_streams` field and stream convenience properties to `EmbyMediaItem` (models.py)
- Updated `parse_media_item` to extract and parse `MediaStreams` from API response (models.py)
- Added 6 `@property` methods on `EmbyMediaPlayer` that delegate to session's `EmbyMediaItem` (media_player.py)

### Testing

43 new tests covering:
- `EmbyMediaStream` dataclass creation, immutability, defaults
- `EmbyMediaItem` stream properties (codec, display_title, channel_layout, video_stream, audio_stream)
- `parse_media_item` MediaStreams extraction (with, without, empty, partial)
- `EmbyMediaPlayer` entity attribute delegation (playing, not playing, no session)

Fixes #334